### PR TITLE
ci: if the "pnpm install" command fails, retry this command 10 times

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,6 @@ jobs:
               echo
               echo '[!]' retry for the second time
 
-              echo '>' rm -rf ~/.pnpm-store
-              rm -rf ~/.pnpm-store
-
               echo '>' npm i -g pnpm@5.7.0
               npm i -g pnpm@5.7.0
             fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,8 +81,8 @@ jobs:
               echo
               echo '[!]' retry for the second time
 
-              echo '>' rm -rf ~/.pnpm-store ./node_modules
-              rm -rf ~/.pnpm-store ./node_modules
+              echo '>' rm -rf ~/.pnpm-store
+              rm -rf ~/.pnpm-store
 
               echo '>' npm i -g pnpm@5.7.0
               npm i -g pnpm@5.7.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,6 @@ jobs:
         run: |
           for i in {1..2} ; do
             if [ ${i} -ne 1 ]; then
-              sleep 5
               echo
               echo '[!]' retry for the second time
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,22 @@ jobs:
       - name: Install pnpm
         run: npm i -g pnpm
       - name: Install Dependencies
-        run: pnpm install
+        shell: bash
+        # In Node.js 14.0.0, the "pnpm install" command may fail. Therefore, if it fails, retry 10 times
+        run: |
+          for i in {1..10} ; do
+            if [ ${i} -ne 1 ]; then
+              sleep 1
+              echo
+              echo '[!]' retry for the "${i}th" time
+            fi
+
+            echo '>' pnpm install
+            if pnpm install; then
+              exit $?
+            fi
+          done
+          exit 1
       - run: pnpm run test-only
   complete:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,8 +78,8 @@ jobs:
               sleep 5
               echo
               echo '[!]' retry for the "${i}th" time
-              echo '>' rm -rf ~/.pnpm-store
-              rm -rf ~/.pnpm-store
+              echo '>' rm -rf ~/.pnpm-store ./node_modules
+              rm -rf ~/.pnpm-store ./node_modules
             fi
 
             echo '>' pnpm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
               sleep 1
               echo
               echo '[!]' retry for the "${i}th" time
+              echo '>' rm -rf ~/.pnpm-store
+              rm -rf ~/.pnpm-store
             fi
 
             echo '>' pnpm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           for i in {1..10} ; do
             if [ ${i} -ne 1 ]; then
-              sleep 1
+              sleep 5
               echo
               echo '[!]' retry for the "${i}th" time
               echo '>' rm -rf ~/.pnpm-store

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,15 +71,21 @@ jobs:
         run: npm i -g pnpm
       - name: Install Dependencies
         shell: bash
-        # In Node.js 14.0.0, the "pnpm install" command may fail. Therefore, if it fails, retry 10 times
+        # In Node.js 14.0.0, the "pnpm install" command may fail.
+        # It may not fail with pnpm version 5.7.0.
+        # see https://github.com/pnpm/pnpm/issues/3007#issuecomment-759985980
         run: |
-          for i in {1..10} ; do
+          for i in {1..2} ; do
             if [ ${i} -ne 1 ]; then
               sleep 5
               echo
-              echo '[!]' retry for the "${i}th" time
+              echo '[!]' retry for the second time
+
               echo '>' rm -rf ~/.pnpm-store ./node_modules
               rm -rf ~/.pnpm-store ./node_modules
+
+              echo '>' npm i -g pnpm@5.7.0
+              npm i -g pnpm@5.7.0
             fi
 
             echo '>' pnpm install


### PR DESCRIPTION
In Node.js 14.0.0, the `pnpm install` command may fail.
Therefore, if it fails, retry 10 times every 1 second.