### PR TITLE
ci: run "build" of npm-scripts before publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
           npm i -g pnpm
           pnpm install
           cd '${{ matrix.path-git-relative }}'
+          pnpm run build --if-present
           if [ -x ./publish.sh ]; then
             GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}'
             matrix_package_name='${{ matrix.package-name }}'


### PR DESCRIPTION
Run the `pnpm run build` command before running the `pnpm publish` command or any custom publish command in the submodule.

In npm-scripts, there are lifecycle scripts "prepare", "prepublish", "prepublishOnly", and "prepack" that provide the same functionality.
However, we do not use them because each package manager has different features and there is a high possibility that they will be deprecated in the future.
see https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish