### PR TITLE
ci: running tests in a Node.js 15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
           - 10.x
           - 12.x
           - 14.x
+          - 15.x
     steps:
       - uses: actions/checkout@v2
       - name: Git Setting


### PR DESCRIPTION
I wasn't aware that Node.js 15 had already been released.