### PR TITLE
feat(ts-type-util-is-readonly-array): create a new package 

### DIFF
--- a/packages/ts-type-utils/has-own-property/tsconfig.build.json
+++ b/packages/ts-type-utils/has-own-property/tsconfig.build.json
@@ -1,13 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    "declarationMap": false,
-
-    /* Advanced Options */
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["*.test-d.ts"]
+  "extends": "../tsconfig.build.json"
 }

--- a/packages/ts-type-utils/has-own-property/tsconfig.json
+++ b/packages/ts-type-utils/has-own-property/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../../tsconfig.base.json"
+  "extends": "../tsconfig.test.json"
 }

--- a/packages/ts-type-utils/is-readonly-array/README.md
+++ b/packages/ts-type-utils/is-readonly-array/README.md
@@ -1,0 +1,57 @@
+# @sounisi5011/ts-type-util-is-readonly-array
+
+[![Go to the latest release page on npm](https://img.shields.io/npm/v/@sounisi5011/ts-type-util-is-readonly-array.svg)](https://www.npmjs.com/package/@sounisi5011/ts-type-util-is-readonly-array)
+
+Fix the type definition of [`Array.isArray()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) method to accept readonly arrays.
+
+## Installation
+
+```sh
+npm install @sounisi5011/ts-type-util-is-readonly-array
+```
+
+```sh
+yarn add @sounisi5011/ts-type-util-is-readonly-array
+```
+
+```sh
+pnpm add @sounisi5011/ts-type-util-is-readonly-array
+```
+
+## Usage
+
+```ts
+import { isReadonlyArray } from '@sounisi5011/ts-type-util-is-readonly-array';
+
+const isArray = Array.isArray as isReadonlyArray;
+
+if (isArray(value)) {
+    // ...
+}
+
+function fn(param: string | readonly string[]) {
+    if (isArray(param)) {
+        // ...
+    } else {
+        // ...
+    }
+}
+```
+
+or
+
+```ts
+import { isReadonlyArray } from '@sounisi5011/ts-type-util-is-readonly-array';
+
+if ((Array.isArray as isReadonlyArray)(value)) {
+    // ...
+}
+
+function fn(param: string | readonly string[]) {
+    if ((Array.isArray as isReadonlyArray)(param)) {
+        // ...
+    } else {
+        // ...
+    }
+}
+```

--- a/packages/ts-type-utils/is-readonly-array/index.test-d.ts
+++ b/packages/ts-type-utils/is-readonly-array/index.test-d.ts
@@ -6,7 +6,9 @@ const isArray = Array.isArray as isReadonlyArray;
 
 // ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
 
-const data1: string | readonly string[] = [];
+declare const gen: <T>() => T;
+
+const data1 = gen<string | readonly string[]>();
 
 if (isArray(data1)) {
     expectType<readonly string[]>(data1);
@@ -20,7 +22,7 @@ if ((Array.isArray as isReadonlyArray)(data1)) {
     expectType<string>(data1);
 }
 
-const data2: string | string[] = [];
+const data2 = gen<string | string[]>();
 
 if (isArray(data2)) {
     expectType<string[]>(data2);
@@ -34,7 +36,7 @@ if ((Array.isArray as isReadonlyArray)(data2)) {
     expectType<string>(data2);
 }
 
-const data3: boolean | string[] | readonly number[] = [];
+const data3 = gen<boolean | string[] | readonly number[]>();
 
 if (isArray(data3)) {
     expectType<string[] | readonly number[]>(data3);

--- a/packages/ts-type-utils/is-readonly-array/index.test-d.ts
+++ b/packages/ts-type-utils/is-readonly-array/index.test-d.ts
@@ -55,3 +55,73 @@ export function test4(param: unknown): void {
         expectType<unknown>(param);
     }
 }
+
+export function test5<T>(param: T): void {
+    if (isArray(param)) {
+        expectType<T & readonly unknown[]>(param);
+    } else {
+        expectType<T>(param);
+    }
+}
+
+/* eslint-disable @typescript-eslint/ban-types */
+export function test6(param: {}): void {
+    if (isArray(param)) {
+        expectType<readonly unknown[]>(param);
+    } else {
+        expectType<{}>(param);
+    }
+    /* eslint-enable */
+}
+
+/*
+ * see https://github.com/orta/TypeScript/blob/c69b255bf69469838a3b755961471a2cdd63fea7/tests/cases/compiler/consistentUnionSubtypeReduction.ts
+ */
+
+declare const a: readonly string[] | string;
+declare const b: string[] | string;
+declare const c: unknown;
+
+if (isArray(a)) {
+    expectType<readonly string[]>(a);
+} else {
+    expectType<string>(a);
+}
+expectType<readonly string[] | string>(a);
+
+if (isArray(b)) {
+    expectType<string[]>(b);
+} else {
+    expectType<string>(b);
+}
+expectType<string[] | string>(b);
+
+if (isArray(c)) {
+    expectType<readonly unknown[]>(c);
+}
+
+export function f<T>(_x: T): void {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const a: readonly T[] | string = null as any;
+    const b: T[] | string = null as any;
+    const c: T = null as any;
+    /* eslint-enable */
+
+    if (isArray(a)) {
+        expectType<readonly T[]>(a);
+    } else {
+        expectType<string>(a);
+    }
+    expectType<readonly T[] | string>(a);
+
+    if (isArray(b)) {
+        expectType<T[]>(b);
+    } else {
+        expectType<string>(b);
+    }
+    expectType<T[] | string>(b);
+
+    if (isArray(c)) {
+        expectType<T & readonly unknown[]>(c);
+    }
+}

--- a/packages/ts-type-utils/is-readonly-array/index.test-d.ts
+++ b/packages/ts-type-utils/is-readonly-array/index.test-d.ts
@@ -6,54 +6,52 @@ const isArray = Array.isArray as isReadonlyArray;
 
 // ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
 
-declare const gen: <T>() => T;
+export function test1(param: string | readonly string[]): void {
+    if (isArray(param)) {
+        expectType<readonly string[]>(param);
+    } else {
+        expectType<string>(param);
+    }
 
-const data1 = gen<string | readonly string[]>();
-
-if (isArray(data1)) {
-    expectType<readonly string[]>(data1);
-} else {
-    expectType<string>(data1);
+    if ((Array.isArray as isReadonlyArray)(param)) {
+        expectType<readonly string[]>(param);
+    } else {
+        expectType<string>(param);
+    }
 }
 
-if ((Array.isArray as isReadonlyArray)(data1)) {
-    expectType<readonly string[]>(data1);
-} else {
-    expectType<string>(data1);
+export function test2(param: string | string[]): void {
+    if (isArray(param)) {
+        expectType<string[]>(param);
+    } else {
+        expectType<string>(param);
+    }
+
+    if ((Array.isArray as isReadonlyArray)(param)) {
+        expectType<string[]>(param);
+    } else {
+        expectType<string>(param);
+    }
 }
 
-const data2 = gen<string | string[]>();
+export function test3(param: boolean | string[] | readonly number[]): void {
+    if (isArray(param)) {
+        expectType<string[] | readonly number[]>(param);
+    } else {
+        expectType<boolean>(param);
+    }
 
-if (isArray(data2)) {
-    expectType<string[]>(data2);
-} else {
-    expectType<string>(data2);
+    if ((Array.isArray as isReadonlyArray)(param)) {
+        expectType<string[] | readonly number[]>(param);
+    } else {
+        expectType<boolean>(param);
+    }
 }
 
-if ((Array.isArray as isReadonlyArray)(data2)) {
-    expectType<string[]>(data2);
-} else {
-    expectType<string>(data2);
-}
-
-const data3 = gen<boolean | string[] | readonly number[]>();
-
-if (isArray(data3)) {
-    expectType<string[] | readonly number[]>(data3);
-} else {
-    expectType<boolean>(data3);
-}
-
-if ((Array.isArray as isReadonlyArray)(data3)) {
-    expectType<string[] | readonly number[]>(data3);
-} else {
-    expectType<boolean>(data3);
-}
-
-const data4: unknown = [];
-
-if (isArray(data4)) {
-    expectType<readonly unknown[]>(data4);
-} else {
-    expectType<unknown>(data4);
+export function test4(param: unknown): void {
+    if (isArray(param)) {
+        expectType<readonly unknown[]>(param);
+    } else {
+        expectType<unknown>(param);
+    }
 }

--- a/packages/ts-type-utils/is-readonly-array/index.test-d.ts
+++ b/packages/ts-type-utils/is-readonly-array/index.test-d.ts
@@ -1,0 +1,57 @@
+import { expectType } from 'tsd';
+
+import type { isReadonlyArray } from '.';
+
+const isArray = Array.isArray as isReadonlyArray;
+
+// ----- ----- ----- ----- ----- ----- ----- ----- ----- ----- //
+
+const data1: string | readonly string[] = [];
+
+if (isArray(data1)) {
+    expectType<readonly string[]>(data1);
+} else {
+    expectType<string>(data1);
+}
+
+if ((Array.isArray as isReadonlyArray)(data1)) {
+    expectType<readonly string[]>(data1);
+} else {
+    expectType<string>(data1);
+}
+
+const data2: string | string[] = [];
+
+if (isArray(data2)) {
+    expectType<string[]>(data2);
+} else {
+    expectType<string>(data2);
+}
+
+if ((Array.isArray as isReadonlyArray)(data2)) {
+    expectType<string[]>(data2);
+} else {
+    expectType<string>(data2);
+}
+
+const data3: boolean | string[] | readonly number[] = [];
+
+if (isArray(data3)) {
+    expectType<string[] | readonly number[]>(data3);
+} else {
+    expectType<boolean>(data3);
+}
+
+if ((Array.isArray as isReadonlyArray)(data3)) {
+    expectType<string[] | readonly number[]>(data3);
+} else {
+    expectType<boolean>(data3);
+}
+
+const data4: unknown = [];
+
+if (isArray(data4)) {
+    expectType<readonly unknown[]>(data4);
+} else {
+    expectType<unknown>(data4);
+}

--- a/packages/ts-type-utils/is-readonly-array/index.ts
+++ b/packages/ts-type-utils/is-readonly-array/index.ts
@@ -1,0 +1,1 @@
+export type isReadonlyArray = (arg: unknown) => arg is readonly unknown[];

--- a/packages/ts-type-utils/is-readonly-array/package.json
+++ b/packages/ts-type-utils/is-readonly-array/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@sounisi5011/ts-type-util-is-readonly-array",
+  "version": "0.0.0",
+  "description": "Fix the type definition of `Array.isArray` method to accept readonly arrays",
+  "keywords": [
+    "ReadonlyArray",
+    "array",
+    "isArray",
+    "isReadonlyArray",
+    "readonly",
+    "ts",
+    "types",
+    "typescript",
+    "util",
+    "utility"
+  ],
+  "homepage": "https://github.com/sounisi5011/npm-packages/tree/main/packages/ts-type-utils/is-readonly-array#readme",
+  "bugs": {
+    "url": "https://github.com/sounisi5011/npm-packages/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sounisi5011/npm-packages.git",
+    "directory": "packages/ts-type-utils/is-readonly-array"
+  },
+  "license": "MIT",
+  "author": "sounisi5011",
+  "types": "./index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "scripts": {
+    "build": "tsc -p ./tsconfig.build.json",
+    "lint:tsc": "tsc --noEmit",
+    "test": "run-s build test:tsd",
+    "test:tsd": "tsd"
+  },
+  "devDependencies": {
+    "tsd": "0.14.0"
+  }
+}

--- a/packages/ts-type-utils/is-readonly-array/package.json
+++ b/packages/ts-type-utils/is-readonly-array/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sounisi5011/ts-type-util-is-readonly-array",
   "version": "0.0.0",
-  "description": "Fix the type definition of `Array.isArray` method to accept readonly arrays",
+  "description": "Fix the type definition of `Array.isArray()` method to accept readonly arrays",
   "keywords": [
     "ReadonlyArray",
     "array",

--- a/packages/ts-type-utils/is-readonly-array/tsconfig.build.json
+++ b/packages/ts-type-utils/is-readonly-array/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    "declarationMap": false,
+
+    /* Advanced Options */
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["*.test-d.ts"]
+}

--- a/packages/ts-type-utils/is-readonly-array/tsconfig.build.json
+++ b/packages/ts-type-utils/is-readonly-array/tsconfig.build.json
@@ -1,13 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    "declarationMap": false,
-
-    /* Advanced Options */
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["*.test-d.ts"]
+  "extends": "../tsconfig.build.json"
 }

--- a/packages/ts-type-utils/is-readonly-array/tsconfig.json
+++ b/packages/ts-type-utils/is-readonly-array/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.base.json"
+}

--- a/packages/ts-type-utils/is-readonly-array/tsconfig.json
+++ b/packages/ts-type-utils/is-readonly-array/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../../tsconfig.base.json"
+  "extends": "../tsconfig.test.json"
 }

--- a/packages/ts-type-utils/tsconfig.base.json
+++ b/packages/ts-type-utils/tsconfig.base.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/ts-type-utils/tsconfig.build.json
+++ b/packages/ts-type-utils/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    "declarationMap": false,
+
+    /* Advanced Options */
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["*/*.test-d.ts"]
+}

--- a/packages/ts-type-utils/tsconfig.test.json
+++ b/packages/ts-type-utils/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    "noEmit": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,11 @@ importers:
       tsd: 0.14.0
     specifiers:
       tsd: 0.14.0
+  packages/ts-type-utils/is-readonly-array:
+    devDependencies:
+      tsd: 0.14.0
+    specifiers:
+      tsd: 0.14.0
 lockfileVersion: 5.2
 packages:
   /@actions/core/1.2.6:


### PR DESCRIPTION
The `Array.isArray` method in TypeScript does not accept read-only arrays.
This small package fixes the type definitions of the `Array.isArray` methods to accept read-only arrays.

- [x] Add `package.json` file
- [x] Add `tsconfig.json` files
- [x] Add type definition files
- [x] Add type definition tests
- [x] Add documentation
- [x] The tests will complete successfully
