### PR TITLE
ci: pin the pnpm version used to 5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
-      - name: Install pnpm
-        run: npm i -g pnpm
+      - name: Install pnpm v5
+        run: npm i -g pnpm@5
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run lint
@@ -66,8 +66,8 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
-      - name: Install pnpm
-        run: npm i -g pnpm
+      - name: Install pnpm v5
+        run: npm i -g pnpm@5
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run test-only

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           readonly CUSTOM_PUBLISH_SCRIPT_PATH=.github/workflows/publish.sh
-          npm i -g pnpm
+          npm i -g pnpm@5
           pnpm install
           cd '${{ matrix.path-git-relative }}'
           pnpm run build --if-present


### PR DESCRIPTION
[pnpm version 6 has been released, which dropped support for Node.js version 10](https://github.com/pnpm/pnpm/releases/tag/v6.0.0).
This project still supports Node.js 10, so pnpm 6 cannot be used.

The update to pnpm 6 is in progress at #26.