### PR TITLE
build: specify pnpm version in the `engines` field of `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "sort-package-json": "1.49.0",
     "ts-jest": "26.5.3",
     "typescript": "4.2.3"
+  },
+  "engines": {
+    "pnpm": "5.x"
   }
 }


### PR DESCRIPTION
[Renovate](https://github.com/renovatebot/renovate) seems to be using pnpm version 6 in updating the `pnpm-lock.yaml` file.
Maybe by using the `engines` field we can tell Renovate what version of pnpm we are using.