### PR TITLE
ci: auto detect pnpm version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,17 +23,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
-      - name: Install pnpm v5
-        run: npm i -g pnpm@5
+      - name: Setup pnpm
+        uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run lint
@@ -49,17 +40,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
-      - name: Install pnpm v5
-        run: npm i -g pnpm@5
+      - name: Setup pnpm
+        uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run fmt-check
@@ -75,17 +57,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
-      - name: Install pnpm v5
-        run: npm i -g pnpm@5
+      - name: Setup pnpm
+        uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run build
@@ -111,17 +84,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
-      - name: Install pnpm v5
-        run: npm i -g pnpm@5
+      - name: Setup pnpm
+        uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
       - run: pnpm run test-only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
@@ -40,6 +49,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
@@ -57,6 +75,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
@@ -84,6 +111,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,16 @@ jobs:
           # Note: The `registry-url` option is required.
           #       If this option is not set, the "npm publish" command will not detect the environment variable NODE_AUTH_TOKEN.
         if: ${{ steps.release.outputs.release_created }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-12.x-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-12.x-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+        if: ${{ steps.release.outputs.release_created }}
       - uses: ./actions/setup-pnpm
         if: ${{ steps.release.outputs.release_created }}
       - name: publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,22 +38,13 @@ jobs:
           # Note: The `registry-url` option is required.
           #       If this option is not set, the "npm publish" command will not detect the environment variable NODE_AUTH_TOKEN.
         if: ${{ steps.release.outputs.release_created }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-12.x-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-12.x-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
+      - uses: ./actions/setup-pnpm
         if: ${{ steps.release.outputs.release_created }}
       - name: publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           readonly CUSTOM_PUBLISH_SCRIPT_PATH=.github/workflows/publish.sh
-          npm i -g pnpm@5
           pnpm install
           cd '${{ matrix.path-git-relative }}'
           pnpm run build --if-present

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -1,0 +1,17 @@
+name: Setup pnpm environment
+author: sounisi5011
+description: Install and set up pnpm, the version of pnpm will be automatically detected from the `engines` field in the `package.json` file in the project root
+runs:
+  using: composite
+  steps:
+    - name: Cache .pnpm-store
+      uses: actions/cache@v2
+      with:
+        path: ~/.pnpm-store
+        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ matrix.node-version }}-
+          ${{ runner.os }}-node-
+          ${{ runner.os }}-
+    - name: Install pnpm v5
+      run: npm i -g pnpm@5

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -9,6 +9,7 @@ runs:
       run: node ${{ github.action_path }}/get-pnpm-data.js
     - shell: bash
       run: |
-        echo '>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
-                 npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+        echo '::group::>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+                          npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+        echo '::endgroup::'
         echo Installed pnpm version: $(pnpm --version)

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -4,12 +4,10 @@ description: Install and set up pnpm, the version of pnpm will be automatically 
 runs:
   using: composite
   steps:
-    - name: Detect Node.js version
-      id: get-node-version
+    - name: Detect pnpm version
+      id: get-pnpm-data
       shell: bash
-      run: |
-        node_version="$(node --version)"
-        echo "::set-output name=node-version::${node_version#v}"
-    - name: Install pnpm v5
+      run: node ${{ github.action_path }}/get-pnpm-data.js
+    - name: Install pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
       shell: bash
-      run: npm i -g pnpm@5
+      run: npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -4,12 +4,10 @@ description: Install and set up pnpm, the version of pnpm will be automatically 
 runs:
   using: composite
   steps:
-    - name: Detect pnpm version
-      id: get-pnpm-data
+    - id: get-pnpm-data
       shell: bash
       run: node ${{ github.action_path }}/get-pnpm-data.js
-    - name: Install pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
-      shell: bash
+    - shell: bash
       run: |
         echo '>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
                  npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -11,4 +11,5 @@ runs:
         node_version="$(node --version)"
         echo "::set-output name=node-version::${node_version#v}"
     - name: Install pnpm v5
+      shell: bash
       run: npm i -g pnpm@5

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -10,14 +10,5 @@ runs:
       run: |
         node_version="$(node --version)"
         echo "::set-output name=node-version::${node_version#v}"
-    - name: Cache .pnpm-store
-      uses: actions/cache@v2
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-node-${{ steps.get-node-version.outputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ steps.get-node-version.outputs.node-version }}-
-          ${{ runner.os }}-node-
-          ${{ runner.os }}-
     - name: Install pnpm v5
       run: npm i -g pnpm@5

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -11,3 +11,4 @@ runs:
       run: |
         echo '>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
                  npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+        echo Installed pnpm version: $(pnpm --version)

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -10,4 +10,6 @@ runs:
       run: node ${{ github.action_path }}/get-pnpm-data.js
     - name: Install pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
       shell: bash
-      run: npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+      run: |
+        echo '>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+                 npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -9,7 +9,7 @@ runs:
       run: node ${{ github.action_path }}/get-pnpm-data.js
     - shell: bash
       run: |
-        echo '::group::>' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
+        echo '::group::$' npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
                           npm i -g pnpm@${{ steps.get-pnpm-data.outputs.pnpm-version-range }}
         echo '::endgroup::'
         echo Installed pnpm version: $(pnpm --version)

--- a/actions/setup-pnpm/action.yaml
+++ b/actions/setup-pnpm/action.yaml
@@ -4,13 +4,19 @@ description: Install and set up pnpm, the version of pnpm will be automatically 
 runs:
   using: composite
   steps:
+    - name: Detect Node.js version
+      id: get-node-version
+      shell: bash
+      run: |
+        node_version="$(node --version)"
+        echo "::set-output name=node-version::${node_version#v}"
     - name: Cache .pnpm-store
       uses: actions/cache@v2
       with:
         path: ~/.pnpm-store
-        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-node-${{ steps.get-node-version.outputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ matrix.node-version }}-
+          ${{ runner.os }}-node-${{ steps.get-node-version.outputs.node-version }}-
           ${{ runner.os }}-node-
           ${{ runner.os }}-
     - name: Install pnpm v5

--- a/actions/setup-pnpm/get-pnpm-data.js
+++ b/actions/setup-pnpm/get-pnpm-data.js
@@ -1,0 +1,24 @@
+function main() {
+  const path = require('path');
+  const pkgJsonPath = path.resolve('package.json');
+  const pkg = require(pkgJsonPath);
+  console.log(`Loaded ${pkgJsonPath}`);
+
+  const { engines } = pkg;
+  if (!engines) throw new Error('`engines` field is not defined');
+  if (typeof engines !== 'object') throw new Error('`engines` field is not object value');
+
+  const pnpmVersionRange = engines.pnpm;
+  if (!pnpmVersionRange) throw new Error('`engines.pnpm` field is not defined');
+  if (typeof pnpmVersionRange !== 'string') throw new Error('`engines.pnpm` field is not string value');
+
+  console.log(`Detect pnpm version: ${pnpmVersionRange}`);
+  console.log(`::set-output name=pnpm-version-range::${pnpmVersionRange || ''}`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.exitCode = 1;
+  console.error(error.message);
+}


### PR DESCRIPTION
The pnpm version is [defined in the `engines` field in the `package.json` file](https://github.com/sounisi5011/npm-packages/blob/1c28c75d3246cc888e1d4e1418a5c8844c593b31/package.json#L56-L58). The version of pnpm used within GitHub Actions should be automatically detected from here.