### PR TITLE
build(pnpm): link local packages to dependencies only if the `workspace:` range protocol is used

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Link local packages to dependencies only if the `workspace:` range protocol is used.
+# see https://pnpm.io/workspaces#link-workspace-packages
+link-workspace-packages = false


### PR DESCRIPTION
This problem was found after we closed https://github.com/sounisi5011/npm-packages/pull/85.
Even if we do *not* use the `workspace:` range protocol intentionally, pnpm will link local packages to the dependencies.
This will reproduce the problem that was fixed in https://github.com/sounisi5011/npm-packages/pull/85/commits/0ee2d65b03e9443f11c4e5135a455b1b31c6bfd3.
So we set [the link-workspace-packages option](https://pnpm.io/workspaces#link-workspace-packages) to `false`.