### PR TITLE
chore(eslint): remove eslint-disable comments targeted by the `@typescript-eslint/dot-notation` rule

### DIFF
--- a/packages/encrypted-archive/src/utils/index.ts
+++ b/packages/encrypted-archive/src/utils/index.ts
@@ -177,7 +177,6 @@ function isErrorConstructor(value: unknown): value is ErrorConstructor {
 }
 
 export function fixNodePrimordialsErrorInstance(oldError: unknown): never {
-    /* eslint-disable @typescript-eslint/dot-notation */
     if (
         isObject(oldError)
         && !(oldError instanceof Error)
@@ -195,7 +194,6 @@ export function fixNodePrimordialsErrorInstance(oldError: unknown): never {
         throw newError;
     }
     throw oldError;
-    /* eslint-enable */
 }
 
 /**
@@ -205,7 +203,7 @@ export function fixNodePrimordialsErrorInstance(oldError: unknown): never {
  * This function will fix the stack trace of the pseudo Error object to the proper one.
  */
 export function fixNodePrimordialsErrorStackTrace(oldError: unknown): never {
-    /* eslint-disable @typescript-eslint/no-throw-literal, @typescript-eslint/dot-notation */
+    /* eslint-disable @typescript-eslint/no-throw-literal */
     if (!(isObject(oldError) && !(oldError instanceof Error))) throw oldError;
     const oldErrorStackTrace = oldError['stack'];
 

--- a/packages/ts-type-utils/has-own-property/index.test-d.ts
+++ b/packages/ts-type-utils/has-own-property/index.test-d.ts
@@ -136,13 +136,6 @@ if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'nonExistent'
     expectType<number | undefined>(obj1.union_undef);
 }
 
-/**
- * Note: Currently, the `dot-notation` rule for `@typescript-eslint/eslint-plugin@4.17.0` conflicts with TypeScript's `noPropertyAccessFromIndexSignature` option
- *       see https://github.com/typescript-eslint/typescript-eslint/issues/3104
- * @todo If `@typescript-eslint/eslint-plugin` supports the `noPropertyAccessFromIndexSignature` option, remove this comment.
- */
-/* eslint-disable @typescript-eslint/dot-notation */
-
 const obj2: Record<string, boolean> = {};
 
 /**


### PR DESCRIPTION
In the distant past, [the "@typescript-eslint/dot-notation" rule] did not detect [TypeScript's "noPropertyAccessFromIndexSignature" option].
However, it is now detected correctly.
The dark days of disabling [the "@typescript-eslint/dot-notation" rule] are over.

[the "@typescript-eslint/dot-notation" rule]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md
[TypeScript's "noPropertyAccessFromIndexSignature" option]: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature