### PR TITLE
ci(github actions): trigger tests with `workflow_dispatch` events as well

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - main
     tags-ignore:
       - "**"
+  workflow_dispatch:
 jobs:
   submodules-finder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Due to the limitation of GitHub Actions, CI will not be run automatically on Pull Requests for releases.
To alleviate this limitation as much as possible, we will add a [`workflow_dispatch` event], which will allow you to run tests manually or via the API.

[`workflow_dispatch` event]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch