### PR TITLE
ci(github actions): the `workflow_dispatch` event should be defined in `ci.yaml`, not in `release.yaml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
       - "**"
     tags-ignore:
       - "**"
+  workflow_dispatch:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
       - main
     tags-ignore:
       - "**"
-  workflow_dispatch:
 jobs:
   submodules-finder:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
       - main
     tags-ignore:
       - "**"
+  workflow_dispatch:
 jobs:
   submodules-finder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will fix the mistake in https://github.com/sounisi5011/npm-packages/pull/92.