### PR TITLE
chore(cli-utils-top-level-await): remove `@sounisi5011/run-if-supported` from the devDependencies

### DIFF
--- a/packages/cli-utils/top-level-await-cli/package.json
+++ b/packages/cli-utils/top-level-await-cli/package.json
@@ -31,11 +31,10 @@
     "lint:tsc": "run-p lint:tsc:*",
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
-    "test": "run-if-supported --verbose run-p test:*",
+    "test": "pnpx -p @sounisi5011/run-if-supported@1.x --yes run-if-supported --verbose run-p test:*",
     "test:jest": "jest"
   },
   "devDependencies": {
-    "@sounisi5011/run-if-supported": "1.0.1",
     "@types/node": "12.x",
     "execa": "5.1.1",
     "ultra-runner": "3.10.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,12 +77,10 @@ importers:
 
   packages/cli-utils/top-level-await-cli:
     specifiers:
-      '@sounisi5011/run-if-supported': 1.0.1
       '@types/node': 12.x
       execa: 5.1.1
       ultra-runner: 3.10.5
     devDependencies:
-      '@sounisi5011/run-if-supported': 1.0.1
       '@types/node': 12.20.14
       execa: 5.1.1
       ultra-runner: 3.10.5


### PR DESCRIPTION
I noticed a circular reference in the project dependencies when I added `@sounisi5011/cli-utils-top-level-await` to the dependency of `@sounisi5011/run-if-supported` in https://github.com/sounisi5011/npm-packages/pull/130.
Due to this circular reference, the build using ultra-runner will fail.
ultra-runner has tried to build `@sounisi5011/run-if-supported` before `@sounisi5011/cli-utils-top-level-await`.
To solve this problem, remove `@sounisi5011/run-if-supported` from the `@sounisi5011/cli-utils-top-level-await` dependency.