### PR TITLE
chore(eslint): enable `import/order` rules for `*.ts` files

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -66,10 +66,6 @@ overrides:
       no-void:
         - error
         - allowAsStatement: true
-      # dprint will sort the import statement.
-      # Note: dprint does not sort CommonJS-style `require()` statements.
-      #       For this reason, this rule should only be disabled for TypeScript.
-      import/order: off
       # TypeScript checks the import statement path.
       # Therefore, there is no need to verify the file path imported by ESLint.
       node/no-missing-import: off

--- a/actions/monorepo-workspace-submodules-finder/tests/main.ts
+++ b/actions/monorepo-workspace-submodules-finder/tests/main.ts
@@ -1,7 +1,7 @@
 import type { hasOwnProperty } from '@sounisi5011/ts-type-util-has-own-property';
 
-import { getPackageDataList, PackageData } from '../src/main';
 import pkg from '../package.json';
+import { getPackageDataList, PackageData } from '../src/main';
 
 describe('getPackageDataList()', () => {
     it('package data should be included', async () => {

--- a/packages/encrypted-archive/src/compress/index.ts
+++ b/packages/encrypted-archive/src/compress/index.ts
@@ -1,8 +1,8 @@
 import type * as stream from 'stream';
 
+import { fixNodePrimordialsErrorStackTrace, printObject } from '../utils';
 import { writeFromIterableToStream } from '../utils/stream';
 import type { AsyncIterableReturn, ObjectValue } from '../utils/type';
-import { fixNodePrimordialsErrorStackTrace, printObject } from '../utils';
 import { createCompress as createBrotliCompress, createDecompress as createBrotliDecompress } from './brotli';
 import { createCompress as createGzipCompress, createDecompress as createGzipDecompress } from './gzip';
 

--- a/packages/encrypted-archive/src/decrypt.ts
+++ b/packages/encrypted-archive/src/decrypt.ts
@@ -1,5 +1,3 @@
-import { StreamReader } from './utils/stream';
-import type { AsyncIterableReturn } from './utils/type';
 import { CryptoAlgorithm, cryptoAlgorithmMap } from './cipher';
 import { CompressOptions, decompressIterable } from './compress';
 import {
@@ -18,6 +16,8 @@ import { nonceState } from './nonce';
 import { validateChunk } from './stream';
 import type { InputDataType, IteratorConverter } from './types';
 import { bufferFrom, fixNodePrimordialsErrorInstance } from './utils';
+import { StreamReader } from './utils/stream';
+import type { AsyncIterableReturn } from './utils/type';
 
 interface DecryptorMetadata {
     algorithm: CryptoAlgorithm;

--- a/packages/encrypted-archive/src/encrypt.ts
+++ b/packages/encrypted-archive/src/encrypt.ts
@@ -1,6 +1,5 @@
 import { randomBytes } from 'crypto';
 
-import type { AsyncIterableReturn } from './utils/type';
 import { CryptoAlgorithm, cryptoAlgorithmMap, CryptoAlgorithmName, defaultCryptoAlgorithmName } from './cipher';
 import { CompressOptions, createCompressor } from './compress';
 import { createHeader, createSimpleHeader } from './header';
@@ -9,6 +8,7 @@ import { nonceState } from './nonce';
 import { validateChunk } from './stream';
 import type { InputDataType, IteratorConverter } from './types';
 import { bufferFrom, convertIterableValue } from './utils';
+import type { AsyncIterableReturn } from './utils/type';
 
 export interface EncryptOptions {
     algorithm?: CryptoAlgorithmName;

--- a/packages/encrypted-archive/src/header/create.ts
+++ b/packages/encrypted-archive/src/header/create.ts
@@ -3,9 +3,9 @@ import { encode as varintEncode } from 'varint';
 import type { CryptoAlgorithmName } from '../cipher';
 import type { CompressOptions } from '../compress';
 import type { NormalizedKeyDerivationOptions } from '../key-derivation-function';
+import { cidByteList } from './content-identifier';
 import { createProtobufHeader } from './protocol-buffers-converter/header';
 import { createProtobufSimpleHeader } from './protocol-buffers-converter/simpleHeader';
-import { cidByteList } from './content-identifier';
 
 export interface SimpleHeaderData {
     crypto: {

--- a/packages/encrypted-archive/src/header/parser.ts
+++ b/packages/encrypted-archive/src/header/parser.ts
@@ -1,10 +1,10 @@
+import { number2hex } from '../utils';
 import type { StreamReaderInterface } from '../utils/stream';
 import type { AsyncIterableReturn } from '../utils/type';
-import { number2hex } from '../utils';
-import { Header, SimpleHeader } from './protocol-buffers/header_pb';
+import { cidNumber } from './content-identifier';
 import { parseProtobufHeader } from './protocol-buffers-converter/header';
 import { parseProtobufSimpleHeader } from './protocol-buffers-converter/simpleHeader';
-import { cidNumber } from './content-identifier';
+import { Header, SimpleHeader } from './protocol-buffers/header_pb';
 import { createHeaderDataParser, parseDataLength, readVarint, validateDataLength } from './utils';
 
 export async function validateCID(reader: StreamReaderInterface): Promise<void> {

--- a/packages/encrypted-archive/src/header/protocol-buffers-converter/header.ts
+++ b/packages/encrypted-archive/src/header/protocol-buffers-converter/header.ts
@@ -1,8 +1,8 @@
 import { isArgon2Options } from '../../key-derivation-function/argon2';
-import { assertType } from '../../utils/type';
 import { cond, getPropFromValue, printObject } from '../../utils';
-import { Header } from '../protocol-buffers/header_pb';
+import { assertType } from '../../utils/type';
 import type { HeaderData } from '../create';
+import { Header } from '../protocol-buffers/header_pb';
 import { createProtobufArgon2Options, parseProtobufArgon2Options } from './argon2Options';
 import { createEnum2value, validateBytesField, validateNumberField } from './utils';
 

--- a/packages/encrypted-archive/src/header/protocol-buffers-converter/simpleHeader.ts
+++ b/packages/encrypted-archive/src/header/protocol-buffers-converter/simpleHeader.ts
@@ -1,5 +1,5 @@
-import { SimpleHeader } from '../protocol-buffers/header_pb';
 import type { SimpleHeaderData } from '../create';
+import { SimpleHeader } from '../protocol-buffers/header_pb';
 import { validateBytesField, validateNumberFieldInRange, validateNumberOptionInRange } from './utils';
 
 const dataName = 'SimpleHeader data';

--- a/packages/encrypted-archive/src/header/protocol-buffers-converter/utils.ts
+++ b/packages/encrypted-archive/src/header/protocol-buffers-converter/utils.ts
@@ -1,5 +1,5 @@
-import type { Cond2, Nullable, OneOrMoreReadonlyArray } from '../../utils/type';
 import { getPropFromValue, printObject } from '../../utils';
+import type { Cond2, Nullable, OneOrMoreReadonlyArray } from '../../utils/type';
 
 function reportNonDefinedField(opts: { fieldName: string; dataName: string }): never {
     throw new Error(`${opts.fieldName} field in ${opts.dataName} is not defined`);

--- a/packages/encrypted-archive/src/key-derivation-function/argon2.ts
+++ b/packages/encrypted-archive/src/key-derivation-function/argon2.ts
@@ -2,9 +2,9 @@ import { isPropAccessible } from '@sounisi5011/ts-utils-is-property-accessible';
 import argon2 from 'argon2-browser';
 import capitalize from 'capitalize';
 
-import { assertType, isInteger, objectEntries, objectFromEntries } from '../utils/type';
-import { bufferFrom, ifFuncThenExec, isNotUndefined, normalizeOptions, printObject } from '../utils';
 import type { BaseKeyDerivationOptions, GetKDFResult } from '.';
+import { bufferFrom, ifFuncThenExec, isNotUndefined, normalizeOptions, printObject } from '../utils';
+import { assertType, isInteger, objectEntries, objectFromEntries } from '../utils/type';
 
 const argon2TypeRecord = {
     argon2d: argon2.ArgonType.Argon2d,

--- a/packages/encrypted-archive/tests/unit/compress.ts
+++ b/packages/encrypted-archive/tests/unit/compress.ts
@@ -1,9 +1,10 @@
 import * as zlib from 'zlib';
 
 import { CompressOptions, createCompressor, decompressIterable } from '../../src/compress';
-import { optGen } from '../helpers/combinations';
-import '../helpers/jest-matchers';
 import { buffer2asyncIterable, iterable2buffer } from '../helpers';
+import { optGen } from '../helpers/combinations';
+// dprint-ignore
+import '../helpers/jest-matchers';
 
 describe('createCompressor()', () => {
     describe('compress data', () => {

--- a/packages/encrypted-archive/tests/unit/header.ts
+++ b/packages/encrypted-archive/tests/unit/header.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as multicodec from 'multicodec';
 import * as varint from 'varint';
 
-import { cidByteList } from '../../src/header/content-identifier';
 import {
     createHeader,
     createSimpleHeader,
@@ -20,9 +19,10 @@ import {
     SimpleHeaderDataWithCiphertextLength,
     validateCID,
 } from '../../src/header';
+import { cidByteList } from '../../src/header/content-identifier';
 import '../helpers/jest-matchers';
-import { DummyStreamReader } from '../helpers/stream';
 import { iterable2buffer, padStartArray } from '../helpers';
+import { DummyStreamReader } from '../helpers/stream';
 
 const MAX_UINT64 = BigInt(2) ** BigInt(64) - BigInt(1);
 

--- a/packages/encrypted-archive/tests/unit/key-derivation-function.ts
+++ b/packages/encrypted-archive/tests/unit/key-derivation-function.ts
@@ -3,8 +3,8 @@ import * as util from 'util';
 
 import escapeStringRegexp from 'escape-string-regexp';
 
-import type { Argon2Options } from '../../src/key-derivation-function/argon2';
 import { getKDF, KeyDerivationOptions } from '../../src/key-derivation-function';
+import type { Argon2Options } from '../../src/key-derivation-function/argon2';
 import { addNegativeNumber, createDummySizeBuffer, rangeArray } from '../helpers';
 
 import '../helpers/jest-matchers';


### PR DESCRIPTION
The `import/order` rule in ESLint had been disabled because it conflicts with dprint.
However, dprint's sorting is incomplete and using ESLint gives the desired result.