### PR TITLE
chore(renovate): automatically update the lock file

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:js-lib", ":semanticCommits"],
+  "extends": ["config:js-lib", ":semanticCommits", ":maintainLockFilesWeekly"],
   "ignorePresets": ["group:monorepos"],
   "ignoreDeps": ["@types/node"],
   "packageRules": [


### PR DESCRIPTION
Added [":maintainLockFilesWeekly" preset](https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly) to Renovate settings to make Renovate update lock files automatically.