### PR TITLE
test(check-pid-file): fix the "remove pid file on finish" test

### DIFF
--- a/packages/check-pid-file/tests/index.ts
+++ b/packages/check-pid-file/tests/index.ts
@@ -76,11 +76,16 @@ describe('isProcessExist()', () => {
                 const isPidFileExists = fsPromises.access(pidFilepath);
                 if (!isLastLoop) {
                     // If the file deletion fails, it will retry up to 10 times.
-                    try {
-                        await isPidFileExists;
+                    if (
+                        await (
+                            isPidFileExists
+                                .then(() => true as const)
+                                .catch(() => false as const)
+                        )
+                    ) {
                         await fsPromises.unlink(pidFilepath);
                         continue;
-                    } catch {}
+                    }
                 }
 
                 await expect(isPidFileExists).rejects


### PR DESCRIPTION
The pid file may fail to be deleted.
Fixed the test so that it will retry up to 10 times if the deletion fails.