### PR TITLE
ci(monorepo-workspace-submodules-finder-action): fix `.github/workflows/post-release.sh`

### DIFF
--- a/actions/monorepo-workspace-submodules-finder/.github/workflows/post-release.sh
+++ b/actions/monorepo-workspace-submodules-finder/.github/workflows/post-release.sh
@@ -22,6 +22,7 @@ exec_group() {
   return $exit_code
 }
 
+exec_group pnpm run -w build:scripts || true
 exec_group pnpm run -w build:package-list || true
 exec_group git add ../../README.md || true
 exec_group git commit -m 'docs: update package list' || true


### PR DESCRIPTION
Before running the `build:package-list` script, the dependencies need to be built.