### PR TITLE
build(scripts/update-package-list): don't define `@typedef` annotation in the function

### DIFF
--- a/scripts/update-package-list/index.js
+++ b/scripts/update-package-list/index.js
@@ -10,6 +10,32 @@ const validateNpmPkgName = require('validate-npm-package-name');
 const { getWorkspaces, getWorkspaceRoot } = require('workspace-tools');
 
 /**
+ * @typedef {Object<string, string | Partial<HeaderData>>} HeaderTable
+ *
+ * @typedef {Object} HeaderData
+ * @property {string} header
+ * @property {function(PackageInfo, UtilFuncs): string} getVersionLink
+ * @property {function(PackageInfo, UtilFuncs): string} getDependenciesLink
+ *
+ * @typedef {Object} PackageInfo
+ * @property {import('workspace-tools').WorkspaceInfo[number]['name']} name
+ * @property {import('workspace-tools').WorkspaceInfo[number]['path']} path
+ * @property {import('workspace-tools').WorkspaceInfo[number]['packageJson']} packageJson
+ * @property {string} version
+ * @property {string} versionLink
+ * @property {string} localURL
+ * @property {string} noScopeName
+ * @property {hostedGitInfo} repoData
+ * @property {string} packagePathURL
+ * @property {string} headerText
+ * @property {string} headerText
+ * @property {string} depsLink
+ *
+ * @typedef {Object} UtilFuncs
+ * @property {typeof strictUriEncode} strictUriEncode
+ */
+
+/**
  * @param {string} message
  */
 function reportError(message) {
@@ -80,30 +106,6 @@ function headerText2markdownAnchor(header) {
 }
 
 /**
- * @typedef {Object} UtilFuncs
- * @property {typeof strictUriEncode} strictUriEncode
- *
- * @typedef {Object} HeaderData
- * @property {string} header
- * @property {function(PackageInfo, UtilFuncs): string} getVersionLink
- * @property {function(PackageInfo, UtilFuncs): string} getDependenciesLink
- *
- * @typedef {Object<string, string | Partial<HeaderData>>} HeaderTable
- *
- * @typedef {Object} PackageInfo
- * @property {import('workspace-tools').WorkspaceInfo[number]['name']} name
- * @property {import('workspace-tools').WorkspaceInfo[number]['path']} path
- * @property {import('workspace-tools').WorkspaceInfo[number]['packageJson']} packageJson
- * @property {string} version
- * @property {string} versionLink
- * @property {string} localURL
- * @property {string} noScopeName
- * @property {hostedGitInfo} repoData
- * @property {string} packagePathURL
- * @property {string} headerText
- * @property {string} headerText
- * @property {string} depsLink
- *
  * @param {HeaderTable} headerTable
  * @param {string} relativePackagePath
  * @returns {HeaderData}

--- a/scripts/update-package-list/index.js
+++ b/scripts/update-package-list/index.js
@@ -90,6 +90,20 @@ function headerText2markdownAnchor(header) {
  *
  * @typedef {Object<string, string | Partial<HeaderData>>} HeaderTable
  *
+ * @typedef {Object} PackageInfo
+ * @property {import('workspace-tools').WorkspaceInfo[number]['name']} name
+ * @property {import('workspace-tools').WorkspaceInfo[number]['path']} path
+ * @property {import('workspace-tools').WorkspaceInfo[number]['packageJson']} packageJson
+ * @property {string} version
+ * @property {string} versionLink
+ * @property {string} localURL
+ * @property {string} noScopeName
+ * @property {hostedGitInfo} repoData
+ * @property {string} packagePathURL
+ * @property {string} headerText
+ * @property {string} headerText
+ * @property {string} depsLink
+ *
  * @param {HeaderTable} headerTable
  * @param {string} relativePackagePath
  * @returns {HeaderData}
@@ -155,21 +169,6 @@ async function updateMarkdown(filepath, rootPackageList, packageRoot) {
         relativePackagePath,
       );
 
-      /**
-       * @typedef {Object} PackageInfo
-       * @property {import('workspace-tools').WorkspaceInfo[number]['name']} name
-       * @property {import('workspace-tools').WorkspaceInfo[number]['path']} path
-       * @property {import('workspace-tools').WorkspaceInfo[number]['packageJson']} packageJson
-       * @property {string} version
-       * @property {string} versionLink
-       * @property {string} localURL
-       * @property {string} noScopeName
-       * @property {hostedGitInfo} repoData
-       * @property {string} packagePathURL
-       * @property {string} headerText
-       * @property {string} headerText
-       * @property {string} depsLink
-       */
       /** @type {PackageInfo} */
       const packageInfo = {
         ...data,


### PR DESCRIPTION
VS Code does not detect any type definitions other than those defined using the `@typedef` annotation in the root.