### PR TITLE
test(ts-utils-is-property-accessible): support for error message format changed in Node.js 16.9.0

### DIFF
--- a/packages/ts-utils/is-property-accessible/tests/index.ts
+++ b/packages/ts-utils/is-property-accessible/tests/index.ts
@@ -34,7 +34,8 @@ describe('isPropertyAccessible()', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         it.each(anyValues.filter(v => !isPropertyAccessible(v)))('%p', (value: any) => {
             expect(() => value.foo).toThrow(TypeError);
-            expect(() => value.foo).toThrow(/^Cannot read property 'foo'/);
+            // Starting with Node.js 16.9.0, the format of error messages has been changed
+            expect(() => value.foo).toThrow(/^Cannot read property 'foo'|^Cannot read properties .*\(reading 'foo'\)$/);
         });
     });
 });


### PR DESCRIPTION
`Cannot read property 'foo' of null`
↓
`Cannot read properties of null (reading 'foo')`