### PR TITLE
test(encrypted-archive): introduce `@sounisi5011/jest-binary-data-matchers`

### DIFF
--- a/packages/encrypted-archive/jest.config.js
+++ b/packages/encrypted-archive/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
       tsconfig: '<rootDir>/tests/tsconfig.json',
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@sounisi5011/jest-binary-data-matchers'],
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests/helpers/'],

--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -95,6 +95,7 @@
   },
   "devDependencies": {
     "@jorgeferrero/stream-to-buffer": "2.0.6",
+    "@sounisi5011/jest-binary-data-matchers": "workspace:^0.0.0 || ^1.0.0",
     "@sounisi5011/run-if-supported": "workspace:^1.0.0",
     "@sounisi5011/ts-type-util-has-own-property": "workspace:^1.0.0",
     "@types/argon2-browser": "1.18.1",

--- a/packages/encrypted-archive/tests/helpers/jest-matchers/index.d.ts
+++ b/packages/encrypted-archive/tests/helpers/jest-matchers/index.d.ts
@@ -6,8 +6,6 @@ type ActualArgs<T extends keyof MatcherFuncs> = (
 
 declare namespace jest {
     interface Matchers<R> {
-        toBeByteSize: (...args: ActualArgs<'toBeByteSize'>) => R;
-        toBeLessThanByteSize: (...args: ActualArgs<'toBeLessThanByteSize'>) => R;
         toThrowWithMessageFixed: (...args: ActualArgs<'toThrowWithMessageFixed'>) => R;
     }
 }

--- a/packages/encrypted-archive/tests/helpers/jest-matchers/matchers.ts
+++ b/packages/encrypted-archive/tests/helpers/jest-matchers/matchers.ts
@@ -1,5 +1,4 @@
 import {
-    ensureNumbers,
     EXPECTED_COLOR,
     getLabelPrinter,
     matcherHint,
@@ -27,42 +26,6 @@ function createMatcherResult(
             return lines.join('\n');
         },
     };
-}
-
-function divide(dividend: number | bigint, divisor: number | bigint): number {
-    if (typeof dividend === 'bigint' || typeof divisor === 'bigint') {
-        const shift = 2 ** 52;
-        return Number(
-            (
-                BigInt(dividend) * BigInt(shift)
-            ) / BigInt(divisor),
-        ) / shift;
-    } else {
-        return dividend / divisor;
-    }
-}
-
-function byteSize(bytes: number | bigint): string {
-    // if (typeof bytes === 'bigint' && bytes <= Number.MAX_SAFE_INTEGER){
-    //     bytes = Number(bytes);
-    // }
-    const [sign, absBytes] = bytes < 0 ? ['-', -bytes] : ['', bytes];
-    const unitData = Object.entries({
-        YiB: BigInt(2) ** BigInt(80),
-        ZiB: BigInt(2) ** BigInt(70),
-        EiB: BigInt(2) ** BigInt(60),
-        PiB: 2 ** 50,
-        TiB: 2 ** 40,
-        GiB: 2 ** 30,
-        MiB: 2 ** 20,
-        KiB: 2 ** 10,
-    }).find(([, from]) => from <= absBytes);
-    if (unitData) {
-        const [unit, from] = unitData;
-        const divedBytes = divide(absBytes, from).toFixed(2).replace(/\.?0+$/, '');
-        return `${sign}${divedBytes} ${unit} (${sign}${absBytes} B)`;
-    }
-    return `${sign}${absBytes} B`;
 }
 
 function printConstructorName(
@@ -156,61 +119,6 @@ function printStringDiff(
             printDiffOrStringify(expected, received, expectedLabel, receivedLabel, true),
         ];
     }
-}
-
-export function toBeByteSize(
-    this: jest.MatcherContext,
-    received: number | bigint,
-    expected: number | bigint,
-): jest.CustomMatcherResult {
-    /**
-     * @see https://github.com/facebook/jest/blob/v26.6.3/packages/expect/src/matchers.ts#L333-L355
-     * @see https://github.com/facebook/jest/blob/v26.6.3/packages/expect/src/matchers.ts#L74-L125
-     */
-    const matcherName = toBeByteSize.name;
-    const isNot = this.isNot;
-    const options: jest.MatcherHintOptions = {
-        isNot,
-        promise: this.promise,
-    };
-    ensureNumbers(received, expected, matcherName, options);
-
-    return createMatcherResult({
-        message: () => [
-            matcherHint(matcherName, undefined, undefined, options),
-            ``,
-            `Expected:${isNot ? ' not' : ''} ${EXPECTED_COLOR(byteSize(expected))}`,
-            `Received:${isNot ? '    ' : ''} ${RECEIVED_COLOR(byteSize(received))}`,
-        ],
-        pass: received == expected, // eslint-disable-line eqeqeq
-    });
-}
-
-export function toBeLessThanByteSize(
-    this: jest.MatcherContext,
-    received: number | bigint,
-    expected: number | bigint,
-): jest.CustomMatcherResult {
-    /**
-     * @see https://github.com/facebook/jest/blob/v26.6.3/packages/expect/src/matchers.ts#L333-L355
-     */
-    const matcherName = toBeLessThanByteSize.name;
-    const isNot = this.isNot;
-    const options: jest.MatcherHintOptions = {
-        isNot,
-        promise: this.promise,
-    };
-    ensureNumbers(received, expected, matcherName, options);
-
-    return createMatcherResult({
-        message: () => [
-            matcherHint(matcherName, undefined, undefined, options),
-            ``,
-            `Expected:${isNot ? ' not' : ''} < ${EXPECTED_COLOR(byteSize(expected))}`,
-            `Received:${isNot ? '    ' : ''}   ${RECEIVED_COLOR(byteSize(received))}`,
-        ],
-        pass: received < expected,
-    });
 }
 
 /**

--- a/packages/encrypted-archive/tests/public-api.ts
+++ b/packages/encrypted-archive/tests/public-api.ts
@@ -74,12 +74,12 @@ describe('encrypt()', () => {
         it('gzip', async () => {
             const uncompressedEncryptedData = await encrypt(cleartext, password);
             const compressedEncryptedData = await encrypt(cleartext, password, { compress: 'gzip' });
-            expect(compressedEncryptedData.byteLength).toBeLessThanByteSize(uncompressedEncryptedData.byteLength);
+            expect(compressedEncryptedData).toBeLessThanByteSize(uncompressedEncryptedData);
         });
         it('brotli', async () => {
             const uncompressedEncryptedData = await encrypt(cleartext, password);
             const compressedEncryptedData = await encrypt(cleartext, password, { compress: 'brotli' });
-            expect(compressedEncryptedData.byteLength).toBeLessThanByteSize(uncompressedEncryptedData.byteLength);
+            expect(compressedEncryptedData).toBeLessThanByteSize(uncompressedEncryptedData);
         });
         it('unknown', async () => {
             await expect(encrypt(cleartext, password, {

--- a/packages/encrypted-archive/tests/stream.ts
+++ b/packages/encrypted-archive/tests/stream.ts
@@ -158,7 +158,7 @@ describe('decryptStream()', () => {
             }
 
             const decryptedData = Buffer.concat(chunkList);
-            expect(decryptedData).toStrictEqual(cleartext);
+            expect(decryptedData).toBytesEqual(cleartext);
         });
     });
     describe('non Buffer chunk', () => {

--- a/packages/encrypted-archive/tests/stream.ts
+++ b/packages/encrypted-archive/tests/stream.ts
@@ -32,7 +32,7 @@ describe('encryptStream()', () => {
             // eslint-disable-next-line jest/no-if
             if (typeof firstChunkLen === 'number') {
                 // eslint-disable-next-line jest/no-conditional-expect
-                expect(chunk.byteLength).toBeLessThanByteSize(firstChunkLen);
+                expect(chunk).toBeLessThanByteSize(firstChunkLen);
             } else {
                 firstChunkLen = chunk.byteLength;
             }

--- a/packages/encrypted-archive/tests/tsconfig.json
+++ b/packages/encrypted-archive/tests/tsconfig.json
@@ -5,7 +5,12 @@
 
     /* Modules */
     "rootDir": "../",
-    "types": ["node", "jest", "jest-extended"],
+    "types": [
+      "node",
+      "jest",
+      "jest-extended",
+      "@sounisi5011/jest-binary-data-matchers"
+    ],
     "resolveJsonModule": true,
 
     /* JavaScript Support */

--- a/packages/encrypted-archive/tests/unit/cipher.ts
+++ b/packages/encrypted-archive/tests/unit/cipher.ts
@@ -51,8 +51,8 @@ describe.each([...cryptoAlgorithmMap.values()].map(algorithm => [algorithm.name,
             expect(() => cleartextPartList.push(decipher.final())).not.toThrow();
 
             const cleartext2 = Buffer.concat(cleartextPartList);
-            expect(cleartext2).toStrictEqual(cleartext);
-            expect(cleartext).toStrictEqual(cleartext2);
+            expect(cleartext2).toBytesEqual(cleartext);
+            expect(cleartext).toBytesEqual(cleartext2);
         });
 
         describe('decryption fail', () => {

--- a/packages/encrypted-archive/tests/unit/compress.ts
+++ b/packages/encrypted-archive/tests/unit/compress.ts
@@ -22,7 +22,7 @@ describe('createCompressor()', () => {
                 const compressedIterable = createCompressor(options)
                     .compressIterable(sourceAsyncIterable);
                 const compressedData = await iterable2buffer(compressedIterable);
-                expect(compressedData.byteLength).toBeLessThanByteSize(data.byteLength);
+                expect(compressedData).toBeLessThanByteSize(data);
             });
             it('reuse compressIterable()', async () => {
                 const { compressIterable } = createCompressor(algorithm);

--- a/packages/encrypted-archive/tests/unit/header.ts
+++ b/packages/encrypted-archive/tests/unit/header.ts
@@ -78,16 +78,18 @@ describe('createHeader()', () => {
             {
                 const headerLength = varint.decode(headerData, headerLenStartOffset);
                 const headerLengthVarintBytes = varint.decode.bytes;
-                expect(headerData.byteLength).toBeByteSize(
-                    cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
-                );
+                expect(headerData)
+                    .toBeByteSize(
+                        cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
+                    );
             }
             {
                 const headerLength = varint.decode(headerData.subarray(headerLenStartOffset));
                 const headerLengthVarintBytes = varint.decode.bytes;
-                expect(headerData.byteLength).toBeByteSize(
-                    cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
-                );
+                expect(headerData)
+                    .toBeByteSize(
+                        cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
+                    );
             }
         });
     });
@@ -123,9 +125,8 @@ describe('createSimpleHeader()', () => {
             const headerLength = varint.decode(headerData);
             const headerLengthVarintBytes = varint.decode.bytes;
             const ciphertextLengthByteLen = varint.encode(dummyHeaderData.ciphertextLength).length;
-            expect(headerData.byteLength).toBeByteSize(
-                headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
-            );
+            expect(headerData)
+                .toBeByteSize(headerLengthVarintBytes + headerLength + ciphertextLengthByteLen);
         });
     });
     it('ciphertext byte length included', () => {

--- a/packages/encrypted-archive/tests/unit/header.ts
+++ b/packages/encrypted-archive/tests/unit/header.ts
@@ -78,18 +78,16 @@ describe('createHeader()', () => {
             {
                 const headerLength = varint.decode(headerData, headerLenStartOffset);
                 const headerLengthVarintBytes = varint.decode.bytes;
-                expect(headerData)
-                    .toBeByteSize(
-                        cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
-                    );
+                expect(headerData).toBeByteSize(
+                    cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
+                );
             }
             {
                 const headerLength = varint.decode(headerData.subarray(headerLenStartOffset));
                 const headerLengthVarintBytes = varint.decode.bytes;
-                expect(headerData)
-                    .toBeByteSize(
-                        cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
-                    );
+                expect(headerData).toBeByteSize(
+                    cidByte.byteLength + headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
+                );
             }
         });
     });
@@ -125,8 +123,9 @@ describe('createSimpleHeader()', () => {
             const headerLength = varint.decode(headerData);
             const headerLengthVarintBytes = varint.decode.bytes;
             const ciphertextLengthByteLen = varint.encode(dummyHeaderData.ciphertextLength).length;
-            expect(headerData)
-                .toBeByteSize(headerLengthVarintBytes + headerLength + ciphertextLengthByteLen);
+            expect(headerData).toBeByteSize(
+                headerLengthVarintBytes + headerLength + ciphertextLengthByteLen,
+            );
         });
     });
     it('ciphertext byte length included', () => {

--- a/packages/encrypted-archive/tests/unit/header.ts
+++ b/packages/encrypted-archive/tests/unit/header.ts
@@ -98,7 +98,7 @@ describe('createHeader()', () => {
             headerData.byteLength - ciphertextLengthByte.byteLength,
             headerData.byteLength,
         );
-        expect(headerInCiphertextLenBytes).toStrictEqual(ciphertextLengthByte);
+        expect(headerInCiphertextLenBytes).toBytesEqual(ciphertextLengthByte);
     });
 });
 
@@ -133,7 +133,7 @@ describe('createSimpleHeader()', () => {
         const headerData = createSimpleHeader(dummyHeaderData);
         const headerInCiphertextLenBytes = headerData
             .subarray(headerData.byteLength - ciphertextLengthByte.byteLength, headerData.byteLength);
-        expect(headerInCiphertextLenBytes).toStrictEqual(ciphertextLengthByte);
+        expect(headerInCiphertextLenBytes).toBytesEqual(ciphertextLengthByte);
     });
     describe('invalid nonce', () => {
         {
@@ -891,7 +891,7 @@ describe('parseCiphertextIterable()', () => {
         ])('%s', async (_, opts, expected) => {
             const reader = new DummyStreamReader(data);
             const resultIterable = parseCiphertextIterable(reader, { ciphertextByteLength: 6, ...opts });
-            await expect(iterable2buffer(resultIterable)).resolves.toStrictEqual(expected);
+            await expect(iterable2buffer(resultIterable)).resolves.toBytesEqual(expected);
         });
     });
     describe('same size data as needed byte length', () => {
@@ -915,7 +915,7 @@ describe('parseCiphertextIterable()', () => {
         ])('%s', async (_, opts, expected) => {
             const reader = new DummyStreamReader(data);
             const resultIterable = parseCiphertextIterable(reader, opts);
-            await expect(iterable2buffer(resultIterable)).resolves.toStrictEqual(expected);
+            await expect(iterable2buffer(resultIterable)).resolves.toBytesEqual(expected);
         });
     });
     describe('smaller data than required byte length', () => {

--- a/packages/encrypted-archive/tests/unit/key-derivation-function.ts
+++ b/packages/encrypted-archive/tests/unit/key-derivation-function.ts
@@ -23,9 +23,9 @@ describe('getKDF()', () => {
             const key = await deriveKey(password, salt, keyLengthBytes);
             expect(key.byteLength).toBeByteSize(keyLengthBytes);
             const key2 = await deriveKey(password, salt, keyLengthBytes);
-            expect(key2).toStrictEqual(key);
+            expect(key2).toBytesEqual(key);
             const key3 = await deriveKey(password, salt, keyLengthBytes);
-            expect(key3).toStrictEqual(key);
+            expect(key3).toBytesEqual(key);
         });
     });
 
@@ -118,9 +118,9 @@ describe('algorithm: Argon2', () => {
                 const key = await deriveKey(password, salt, keyLengthBytes);
                 expect(key.byteLength).toBeByteSize(keyLengthBytes);
                 const key2 = await deriveKey(password, salt, keyLengthBytes);
-                expect(key2).toStrictEqual(key);
+                expect(key2).toBytesEqual(key);
                 const key3 = await deriveKey(password, salt, keyLengthBytes);
-                expect(key3).toStrictEqual(key);
+                expect(key3).toBytesEqual(key);
             });
         });
     });

--- a/packages/encrypted-archive/tests/unit/key-derivation-function.ts
+++ b/packages/encrypted-archive/tests/unit/key-derivation-function.ts
@@ -21,7 +21,7 @@ describe('getKDF()', () => {
 
         it.each(rangeArray(ARGON2_MIN_OUTLEN, 20))('keyLengthBytes: %i', async keyLengthBytes => {
             const key = await deriveKey(password, salt, keyLengthBytes);
-            expect(key.byteLength).toBeByteSize(keyLengthBytes);
+            expect(key).toBeByteSize(keyLengthBytes);
             const key2 = await deriveKey(password, salt, keyLengthBytes);
             expect(key2).toBytesEqual(key);
             const key3 = await deriveKey(password, salt, keyLengthBytes);
@@ -116,7 +116,7 @@ describe('algorithm: Argon2', () => {
                 rangeArray(ARGON2_MIN_OUTLEN, 20),
             )('keyLengthBytes: %i', async keyLengthBytes => {
                 const key = await deriveKey(password, salt, keyLengthBytes);
-                expect(key.byteLength).toBeByteSize(keyLengthBytes);
+                expect(key).toBeByteSize(keyLengthBytes);
                 const key2 = await deriveKey(password, salt, keyLengthBytes);
                 expect(key2).toBytesEqual(key);
                 const key3 = await deriveKey(password, salt, keyLengthBytes);

--- a/packages/encrypted-archive/tests/unit/nonce.ts
+++ b/packages/encrypted-archive/tests/unit/nonce.ts
@@ -16,7 +16,7 @@ describe('class Nonce', () => {
         it.each(rangeArray(MIN_NONCE_LENGTH, MAX_NONCE_LENGTH))('byteLength: %i', len => {
             const nonceState = new Nonce();
             const nonce = nonceState.create(len); // invocation: 0
-            expect(nonce.byteLength).toBeByteSize(len);
+            expect(nonce).toBeByteSize(len);
             const currentFixedField = nonce.subarray(0, 7);
             expect(nonce).toBytesEqual(
                 Buffer.from(padEndArray([...currentFixedField, 0x00, 0x00], len, 0)),

--- a/packages/encrypted-archive/tests/unit/nonce.ts
+++ b/packages/encrypted-archive/tests/unit/nonce.ts
@@ -18,22 +18,22 @@ describe('class Nonce', () => {
             const nonce = nonceState.create(len); // invocation: 0
             expect(nonce.byteLength).toBeByteSize(len);
             const currentFixedField = nonce.subarray(0, 7);
-            expect(nonce).toStrictEqual(
+            expect(nonce).toBytesEqual(
                 Buffer.from(padEndArray([...currentFixedField, 0x00, 0x00], len, 0)),
             );
 
             // invocation: 1
-            expect(nonceState.create(len)).toStrictEqual(
+            expect(nonceState.create(len)).toBytesEqual(
                 Buffer.from(padEndArray([...currentFixedField, 0x01, 0x00], len, 0)),
             );
 
             // invocation: 2
-            expect(nonceState.create(len)).toStrictEqual(
+            expect(nonceState.create(len)).toBytesEqual(
                 Buffer.from(padEndArray([...currentFixedField, 0x02, 0x00], len, 0)),
             );
 
             // invocation: 3
-            expect(nonceState.create(len)).toStrictEqual(
+            expect(nonceState.create(len)).toBytesEqual(
                 Buffer.from(padEndArray([...currentFixedField, 0x03, 0x00], len, 0)),
             );
         });
@@ -68,7 +68,7 @@ describe('class Nonce', () => {
             it.each(rangeArray(1, 9).map(BigInt))('+%i', addInvocationCount => {
                 const nonceState = new Nonce();
                 const newNonce = nonceState.createFromInvocationCountDiff(prevNonce, addInvocationCount);
-                expect([...newNonce]).toStrictEqual([...tooSmallFixedField, Number(addInvocationCount)]);
+                expect(newNonce).toBytesEqual(Buffer.from([...tooSmallFixedField, Number(addInvocationCount)]));
             });
         });
 
@@ -128,7 +128,7 @@ describe('class Nonce', () => {
             ]))('%s', (_, addInvocationCount, expected) => {
                 const nonceState = new Nonce();
                 const newNonce = nonceState.createFromInvocationCountDiff(prevNonce, BigInt(addInvocationCount));
-                expect([...newNonce]).toStrictEqual(expected);
+                expect(newNonce).toBytesEqual(Buffer.from(expected));
             });
         });
 
@@ -137,12 +137,12 @@ describe('class Nonce', () => {
             const currentNonce = nonceState.create(9);
             const prevNonce = new Uint8Array([...tooSmallFixedField, 0x00]);
 
-            expect([...currentNonce.subarray(0, 7)])
-                .not.toStrictEqual([...prevNonce.subarray(0, 7)]);
+            expect(currentNonce.subarray(0, 7))
+                .not.toBytesEqual(prevNonce.subarray(0, 7));
 
             const newNonce = nonceState.createFromInvocationCountDiff(prevNonce, BigInt(0x99));
-            expect([...newNonce])
-                .toStrictEqual([...tooSmallFixedField, 0x99]);
+            expect(newNonce)
+                .toBytesEqual(Buffer.from([...tooSmallFixedField, 0x99]));
         });
 
         describe('update state', () => {
@@ -154,19 +154,19 @@ describe('class Nonce', () => {
                 nonceState.create(9); // invocation: 2
                 nonceState.create(9); // invocation: 3
                 // invocation: 4
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 4, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 4, 0x00]));
 
                 // invocation: 4 -> (0 + 1) because currentFixedField < tooLargeFixedField
-                expect([...nonceState.createFromInvocationCountDiff(
+                expect(nonceState.createFromInvocationCountDiff(
                     Buffer.from([...tooLargeFixedField, 0, 0x00]),
                     BigInt(1),
-                )])
-                    .toStrictEqual([...tooLargeFixedField, 1, 0x00]);
+                ))
+                    .toBytesEqual(Buffer.from([...tooLargeFixedField, 1, 0x00]));
 
                 // invocation: 2
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...tooLargeFixedField, 2, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...tooLargeFixedField, 2, 0x00]));
             });
             it('invocation field value is too large', () => {
                 const nonceState = new Nonce();
@@ -174,30 +174,30 @@ describe('class Nonce', () => {
                 nonceState.create(9); // invocation: 1
                 nonceState.create(9); // invocation: 2
                 // invocation: 3
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 3, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 3, 0x00]));
 
                 // invocation: 3 -> 43 because 3 < (42 + 1)
-                expect([...nonceState.createFromInvocationCountDiff(
+                expect(nonceState.createFromInvocationCountDiff(
                     Buffer.from([...currentFixedField, 42, 0x00]),
                     BigInt(1),
-                )])
-                    .toStrictEqual([...currentFixedField, 43, 0x00]);
+                ))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 43, 0x00]));
 
                 // invocation: 44
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 44, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 44, 0x00]));
 
                 // invocation: 44 -> 54 because 44 < (4 + 50)
-                expect([...nonceState.createFromInvocationCountDiff(
+                expect(nonceState.createFromInvocationCountDiff(
                     Buffer.from([...currentFixedField, 4, 0x00]),
                     BigInt(50),
-                )])
-                    .toStrictEqual([...currentFixedField, 54, 0x00]);
+                ))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 54, 0x00]));
 
                 // invocation: 55
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 55, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 55, 0x00]));
             });
         });
 
@@ -206,8 +206,8 @@ describe('class Nonce', () => {
                 const nonceState = new Nonce();
                 const currentFixedField = nonceState.create(9).subarray(0, 7); // invocation: 0
                 // invocation: 1
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x01, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x01, 0x00]));
 
                 // can not update invocation because not currentFixedField < tooSmallFixedField
                 nonceState.createFromInvocationCountDiff(
@@ -215,8 +215,8 @@ describe('class Nonce', () => {
                     BigInt(1),
                 );
                 // invocation: 2
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x02, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x02, 0x00]));
 
                 // can not update invocation
                 nonceState.createFromInvocationCountDiff(
@@ -232,8 +232,8 @@ describe('class Nonce', () => {
                     BigInt(1),
                 );
                 // invocation: 3
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x03, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x03, 0x00]));
 
                 // can not update invocation
                 nonceState.createFromInvocationCountDiff(
@@ -253,8 +253,8 @@ describe('class Nonce', () => {
                     BigInt(1),
                 );
                 // invocation: 4
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x04, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x04, 0x00]));
             });
             it('invocation field value is too small', () => {
                 const nonceState = new Nonce();
@@ -265,8 +265,8 @@ describe('class Nonce', () => {
                 nonceState.create(9); // invocation: 4
                 nonceState.create(9); // invocation: 5
                 // invocation: 6
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x06, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x06, 0x00]));
 
                 // can not update invocation because equals fixed field and not 6 < 2
                 nonceState.createFromInvocationCountDiff(
@@ -274,8 +274,8 @@ describe('class Nonce', () => {
                     BigInt(1),
                 );
                 // invocation: 7
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x07, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x07, 0x00]));
             });
         });
 
@@ -333,8 +333,8 @@ describe('class Nonce', () => {
                     BigInt(addFixedField),
                     BigInt(0),
                 );
-                expect([...newNonce])
-                    .toStrictEqual([...createFixedField(42 + addFixedField), 0x00]);
+                expect(newNonce)
+                    .toBytesEqual(Buffer.from([...createFixedField(42 + addFixedField), 0x00]));
             });
         });
 
@@ -347,8 +347,8 @@ describe('class Nonce', () => {
                     BigInt(1),
                     BigInt(resetInvocationCount),
                 );
-                expect([...newNonce])
-                    .toStrictEqual([...createFixedField(2 + 1), resetInvocationCount]);
+                expect(newNonce)
+                    .toBytesEqual(Buffer.from([...createFixedField(2 + 1), resetInvocationCount]));
             });
         });
 
@@ -404,7 +404,7 @@ describe('class Nonce', () => {
                     BigInt(1),
                     BigInt(resetInvocationCount),
                 );
-                expect([...newNonce]).toStrictEqual(expected);
+                expect(newNonce).toBytesEqual(Buffer.from(expected));
             });
         });
 
@@ -413,12 +413,12 @@ describe('class Nonce', () => {
             const currentNonce = nonceState.create(9);
             const prevNonce = new Uint8Array([...createFixedField(0x03), 0x00]);
 
-            expect([...currentNonce.subarray(0, 7)])
-                .not.toStrictEqual([...prevNonce.subarray(0, 7)]);
+            expect(currentNonce.subarray(0, 7))
+                .not.toBytesEqual(prevNonce.subarray(0, 7));
 
             const newNonce = nonceState.createFromFixedFieldDiff(prevNonce, BigInt(1), BigInt(0));
-            expect([...newNonce])
-                .toStrictEqual([...createFixedField(0x03 + 1), 0x00]);
+            expect(newNonce)
+                .toBytesEqual(Buffer.from([...createFixedField(0x03 + 1), 0x00]));
         });
 
         describe('update state', () => {
@@ -431,21 +431,21 @@ describe('class Nonce', () => {
                 nonceState.create(9); // fixed: currentFixedField, invocation: 2
                 nonceState.create(9); // fixed: currentFixedField, invocation: 3
                 // fixed: currentFixedField, invocation: 4
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 4, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 4, 0x00]));
 
                 // fixed: currentFixedField -> ([0x00, ..., 0x01] + 1) because currentFixedField < ([0x00, ..., 0x01] + 1)
                 // invocation: 4 -> 0 because currentFixedField < ([0x00, ..., 0x01] + 1)
-                expect([...nonceState.createFromFixedFieldDiff(
+                expect(nonceState.createFromFixedFieldDiff(
                     Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00]),
                     BigInt(1),
                     BigInt(0),
-                )])
-                    .toStrictEqual([0x00 + 1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0]);
+                ))
+                    .toBytesEqual(Buffer.from([0x00 + 1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0]));
 
                 // fixed: ([0x00, ..., 0x01] + 1), invocation: 1
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([0x00 + 1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 1, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([0x00 + 1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 1, 0x00]));
             });
             it('invocation field value is too large', () => {
                 const nonceState = new Nonce();
@@ -461,20 +461,20 @@ describe('class Nonce', () => {
                 nonceState.create(9); // invocation: 12
                 nonceState.create(9); // invocation: 13
                 // invocation: 14
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 14, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 14, 0x00]));
 
                 // invocation: 14 -> 42 because 14 < 42
-                expect([...nonceState.createFromFixedFieldDiff(
+                expect(nonceState.createFromFixedFieldDiff(
                     Buffer.from([...prevFixedField, 121]),
                     BigInt(1),
                     BigInt(42),
-                )])
-                    .toStrictEqual([...currentFixedField, 42]);
+                ))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 42]));
 
                 // fixed: currentFixedField, invocation: 43
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 43, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 43, 0x00]));
             });
         });
 
@@ -483,8 +483,8 @@ describe('class Nonce', () => {
                 const nonceState = new Nonce();
                 const currentFixedField = nonceState.create(9).subarray(0, 7); // invocation: 0
                 // fixed: currentFixedField, invocation: 1
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x01, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x01, 0x00]));
 
                 // can not update fixed field because not currentFixedField < (tooSmallFixedField + 1)
                 nonceState.createFromFixedFieldDiff(
@@ -493,8 +493,8 @@ describe('class Nonce', () => {
                     BigInt(0),
                 );
                 // fixed: currentFixedField, invocation: 2
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x02, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x02, 0x00]));
 
                 // can not update fixed field
                 nonceState.createFromFixedFieldDiff(
@@ -513,8 +513,8 @@ describe('class Nonce', () => {
                     BigInt(0),
                 );
                 // fixed: currentFixedField, invocation: 3
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 0x03, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 0x03, 0x00]));
             });
             it('invocation field value is too small', () => {
                 const nonceState = new Nonce();
@@ -533,8 +533,8 @@ describe('class Nonce', () => {
                 nonceState.create(9); // invocation: 15
                 nonceState.create(9); // invocation: 16
                 // invocation: 17
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 17, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 17, 0x00]));
 
                 // can not update invocation because equals fixed field and not 18 < 12
                 nonceState.createFromFixedFieldDiff(
@@ -543,8 +543,8 @@ describe('class Nonce', () => {
                     BigInt(12),
                 );
                 // invocation: 18
-                expect([...nonceState.create(9)])
-                    .toStrictEqual([...currentFixedField, 18, 0x00]);
+                expect(nonceState.create(9))
+                    .toBytesEqual(Buffer.from([...currentFixedField, 18, 0x00]));
             });
         });
 
@@ -820,29 +820,29 @@ describe('class Nonce', () => {
         expect(nonceState.createFromInvocationCountDiff(
             Buffer.from([...tooLargeFixedField, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
             BigInt(1),
-        )).toStrictEqual(
+        )).toBytesEqual(
             Buffer.from([...tooLargeFixedField, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
         );
-        expect(nonceState.create(tooLargeFixedField.length + 8)).toStrictEqual(
+        expect(nonceState.create(tooLargeFixedField.length + 8)).toBytesEqual(
             Buffer.from([...tooLargeFixedField, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
         );
     });
 
     it('increment fixed field if invocation field overflows', () => {
         const nonceState = new Nonce();
-        expect([...nonceState.createFromInvocationCountDiff(
+        expect(nonceState.createFromInvocationCountDiff(
             Buffer.from([0x00, ...tooLargeFixedField.slice(1), 0xFE, 0xFF]),
             BigInt(1),
-        )]).toStrictEqual([0x00, ...tooLargeFixedField.slice(1), 0xFF, 0xFF]);
+        )).toBytesEqual(Buffer.from([0x00, ...tooLargeFixedField.slice(1), 0xFF, 0xFF]));
         // If the invocation field overflows, increment the fixed field.
-        expect(nonceState.create(9)).toStrictEqual(
+        expect(nonceState.create(9)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x00, 0x00]),
         );
-        expect(nonceState.create(9)).toStrictEqual(
+        expect(nonceState.create(9)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x01, 0x00]),
         );
         // Incrementing the fixed field is kept even if there is space for more bytes in the invocation field.
-        expect(nonceState.create(10)).toStrictEqual(
+        expect(nonceState.create(10)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x02, 0x00, 0x00]),
         );
     });
@@ -852,19 +852,19 @@ describe('class Nonce', () => {
         expect(nonceState.createFromInvocationCountDiff(
             Buffer.from([0x00, ...tooLargeFixedField.slice(1), 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
             BigInt(1),
-        )).toStrictEqual(
+        )).toBytesEqual(
             Buffer.from([0x00, ...tooLargeFixedField.slice(1), 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
         );
-        expect(nonceState.create(15)).toStrictEqual(
+        expect(nonceState.create(15)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         );
-        expect(nonceState.create(15)).toStrictEqual(
+        expect(nonceState.create(15)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         );
-        expect(nonceState.create(15)).toStrictEqual(
+        expect(nonceState.create(15)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
         );
-        expect(nonceState.create(9)).toStrictEqual(
+        expect(nonceState.create(9)).toBytesEqual(
             Buffer.from([0x01, ...tooLargeFixedField.slice(1), 0x03, 0x00]),
         );
     });
@@ -876,7 +876,7 @@ describe('class Nonce', () => {
         expect(nonceState.createFromInvocationCountDiff(
             Buffer.from([...fixedField, 0xFE, 0xFF]),
             BigInt(1),
-        )).toStrictEqual(
+        )).toBytesEqual(
             Buffer.from([...fixedField, 0xFF, 0xFF]),
         );
         expect(() => nonceState.create(9)).toThrowWithMessageFixed(
@@ -885,20 +885,20 @@ describe('class Nonce', () => {
         );
 
         // If the nonce bytes are increased, errors will no longer occur.
-        expect(nonceState.create(10)).toStrictEqual(
+        expect(nonceState.create(10)).toBytesEqual(
             Buffer.from([...fixedField, 0x00, 0x00, 0x01]),
         );
-        expect(nonceState.create(10)).toStrictEqual(
+        expect(nonceState.create(10)).toBytesEqual(
             Buffer.from([...fixedField, 0x01, 0x00, 0x01]),
         );
-        expect(nonceState.create(10)).toStrictEqual(
+        expect(nonceState.create(10)).toBytesEqual(
             Buffer.from([...fixedField, 0x02, 0x00, 0x01]),
         );
 
         expect(nonceState.createFromInvocationCountDiff(
             Buffer.from([...fixedField, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
             BigInt(1),
-        )).toStrictEqual(
+        )).toBytesEqual(
             Buffer.from([...fixedField, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
         );
         expect(() => nonceState.create(15)).toThrowWithMessageFixed(

--- a/packages/encrypted-archive/tests/unit/utils/stream.ts
+++ b/packages/encrypted-archive/tests/unit/utils/stream.ts
@@ -9,7 +9,7 @@ describe('class StreamReader', () => {
             const targetStream = stream.Readable.from([]);
             const reader = new StreamReader(targetStream);
             await expect(reader.read(1)).resolves
-                .toStrictEqual(Buffer.from([]));
+                .toBytesEqual(Buffer.from([]));
         });
         describe.each([
             ['non empty stream', [[0, 1, 2, 3, 4, 5]]],
@@ -34,10 +34,10 @@ describe('class StreamReader', () => {
                 if (input.offset === undefined) {
                     // eslint-disable-next-line jest/no-conditional-expect
                     await expect(reader.read(input.size)).resolves
-                        .toStrictEqual(expectedBuffer);
+                        .toBytesEqual(expectedBuffer);
                 }
                 await expect(reader.read(input.size, input.offset)).resolves
-                    .toStrictEqual(expectedBuffer);
+                    .toBytesEqual(expectedBuffer);
             });
         });
         it('multi read', async () => {
@@ -58,35 +58,35 @@ describe('class StreamReader', () => {
             expect(readCount).toBe(0);
 
             await expect(reader.read(0)).resolves
-                .toStrictEqual(Buffer.from([]));
+                .toBytesEqual(Buffer.from([]));
             expect(readCount).toBe(0);
 
             await expect(reader.read(1)).resolves
-                .toStrictEqual(Buffer.from([0]));
+                .toBytesEqual(Buffer.from([0]));
             expect(readCount).toBe(1);
 
             await expect(reader.read(4)).resolves
-                .toStrictEqual(Buffer.from([0, 1, 2, 3]));
+                .toBytesEqual(Buffer.from([0, 1, 2, 3]));
             expect(readCount).toBe(1);
 
             await expect(reader.read(5)).resolves
-                .toStrictEqual(Buffer.from([0, 1, 2, 3, 4]));
+                .toBytesEqual(Buffer.from([0, 1, 2, 3, 4]));
             expect(readCount).toBe(2);
 
             await expect(reader.read(4)).resolves
-                .toStrictEqual(Buffer.from([0, 1, 2, 3]));
+                .toBytesEqual(Buffer.from([0, 1, 2, 3]));
             expect(readCount).toBe(2);
 
             await expect(reader.read(2, 3)).resolves
-                .toStrictEqual(Buffer.from([3, 4]));
+                .toBytesEqual(Buffer.from([3, 4]));
             expect(readCount).toBe(2);
 
             await expect(reader.read(2, 4)).resolves
-                .toStrictEqual(Buffer.from([4, 5]));
+                .toBytesEqual(Buffer.from([4, 5]));
             expect(readCount).toBe(3);
 
             await expect(reader.read(10, 4)).resolves
-                .toStrictEqual(Buffer.from([4, 5, 6, 7, 8]));
+                .toBytesEqual(Buffer.from([4, 5, 6, 7, 8]));
             expect(readCount).toBe(3);
         });
     });
@@ -135,7 +135,7 @@ describe('class StreamReader', () => {
             })());
             const reader = new StreamReader(targetStream);
 
-            await expect(reader.read(2)).resolves.toStrictEqual(Buffer.from([0, 1]));
+            await expect(reader.read(2)).resolves.toBytesEqual(Buffer.from([0, 1]));
             {
                 const entryList: ReadEntry[] = [];
                 for await (const entry of reader.readIterator(3)) {
@@ -157,7 +157,7 @@ describe('class StreamReader', () => {
                 ]);
             }
             // always seek because storing huge data is inefficient
-            await expect(reader.read(2)).resolves.toStrictEqual(Buffer.from([3, 4]));
+            await expect(reader.read(2)).resolves.toBytesEqual(Buffer.from([3, 4]));
             await expect(reader.isEnd()).resolves.toBeFalse();
 
             {
@@ -181,7 +181,7 @@ describe('class StreamReader', () => {
                 ]);
             }
 
-            await expect(reader.read(1)).resolves.toStrictEqual(Buffer.from([]));
+            await expect(reader.read(1)).resolves.toBytesEqual(Buffer.from([]));
             await expect(reader.isEnd()).resolves.toBeTrue();
             {
                 const entryList: ReadEntry[] = [];
@@ -208,7 +208,7 @@ describe('class StreamReader', () => {
             })());
             const reader = new StreamReader(targetStream);
 
-            await expect(reader.read(2)).resolves.toStrictEqual(Buffer.from([0, 1]));
+            await expect(reader.read(2)).resolves.toBytesEqual(Buffer.from([0, 1]));
             {
                 const entryList: ReadEntry[] = [];
                 for await (const entry of reader.readIterator(3)) {
@@ -237,7 +237,7 @@ describe('class StreamReader', () => {
             }
 
             // the `read()` method merges the chunks as it reads them
-            await expect(reader.read(3)).resolves.toStrictEqual(Buffer.from([3, 4, 5]));
+            await expect(reader.read(3)).resolves.toBytesEqual(Buffer.from([3, 4, 5]));
             {
                 const entryList: ReadEntry[] = [];
                 for await (const entry of reader.readIterator(999, 1)) {
@@ -278,7 +278,7 @@ describe('class StreamReader', () => {
                 ]);
             }
 
-            await expect(reader.read(1)).resolves.toStrictEqual(Buffer.from([]));
+            await expect(reader.read(1)).resolves.toBytesEqual(Buffer.from([]));
             await expect(reader.isEnd()).resolves.toBeTrue();
             {
                 const entryList: ReadEntry[] = [];
@@ -313,7 +313,7 @@ describe('class StreamReader', () => {
 
                     await reader.seek(offset);
                     await expect(reader.read(3, 0)).resolves
-                        .toStrictEqual(Buffer.from(expected));
+                        .toBytesEqual(Buffer.from(expected));
                 });
             });
             describe('after read', () => {
@@ -328,10 +328,10 @@ describe('class StreamReader', () => {
                     const reader = new StreamReader(targetStream);
 
                     await expect(reader.read(3, 0)).resolves
-                        .toStrictEqual(Buffer.from([9, 8, 7]));
+                        .toBytesEqual(Buffer.from([9, 8, 7]));
                     await reader.seek(offset);
                     await expect(reader.read(3, 0)).resolves
-                        .toStrictEqual(Buffer.from(expected));
+                        .toBytesEqual(Buffer.from(expected));
                 });
             });
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,7 @@ importers:
   packages/encrypted-archive:
     specifiers:
       '@jorgeferrero/stream-to-buffer': 2.0.6
+      '@sounisi5011/jest-binary-data-matchers': workspace:^0.0.0 || ^1.0.0
       '@sounisi5011/run-if-supported': workspace:^1.0.0
       '@sounisi5011/stream-transform-from': workspace:^1.0.0
       '@sounisi5011/ts-type-util-has-own-property': workspace:^1.0.0
@@ -242,6 +243,7 @@ importers:
       varint: 6.0.0
     devDependencies:
       '@jorgeferrero/stream-to-buffer': 2.0.6
+      '@sounisi5011/jest-binary-data-matchers': link:../jest-matchers/binary-data
       '@sounisi5011/run-if-supported': link:../cli/run-if-supported
       '@sounisi5011/ts-type-util-has-own-property': link:../ts-type-utils/has-own-property
       '@types/argon2-browser': 1.18.1


### PR DESCRIPTION
- [x] add `@sounisi5011/jest-binary-data-matchers` to devDependencies
- [x] setup to use `@sounisi5011/jest-binary-data-matchers`
- [x] remove local matchers
    - [x] `.toBeByteSize()`
    - [x] `.toBeLessThanByteSize()`
- [x] use `.toBytesEqual()`
- [x] pass the raw `TypedArray` to `expected` arguments