### PR TITLE
fix(ts-type-util-has-own-property): support for optional properties of union types with `undefined` type

### DIFF
--- a/packages/ts-type-utils/has-own-property/README.md
+++ b/packages/ts-type-utils/has-own-property/README.md
@@ -58,6 +58,31 @@ if (hasOwnProp(obj, 'prop')) {
 }
 ```
 
+#### Optional property for union types with `undefined`
+
+Since TypeScript 4.4, when [the `exactOptionalPropertyTypes` option](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) is enabled, [optional properties are no longer union types by default](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#exact-optional-property-types---exactoptionalpropertytypes).
+In this case, it is possible to specify the union type with `undefined` type as an optional property.
+The `hasOwnProperty` type will not remove the `undefined` type of a union type whose `undefined` type has been explicitly specified.
+
+```ts
+import { hasOwnProperty } from '@sounisi5011/ts-type-util-has-own-property';
+
+const hasOwnProp = Object.prototype.hasOwnProperty.call as hasOwnProperty;
+
+// ----- //
+
+interface Obj {
+    prop?: string | undefined;
+}
+
+const obj: Obj = {};
+
+if (hasOwnProp(obj, 'prop')) {
+    // If the `exactOptionalPropertyTypes` option is true, `obj.prop` is `string | undefined` type.
+    // If the `exactOptionalPropertyTypes` option is false, `obj.prop` is `string` type.
+}
+```
+
 ### Union type property with `undefined`
 
 If it is not an optional property, the `undefined` type should not be removed.

--- a/packages/ts-type-utils/has-own-property/index.test-d.ts
+++ b/packages/ts-type-utils/has-own-property/index.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 
 import type { hasOwnProperty } from '.';
 
@@ -8,6 +8,7 @@ const obj1: {
     require: number;
     optional?: number;
     union_undef: number | undefined;
+    optional_union_undef?: boolean | undefined;
 } = { require: 42, union_undef: undefined };
 
 expectType<number>(obj1.require);
@@ -19,6 +20,7 @@ if (hasOwnProp(obj1, 'require')) {
 
     expectType<number | undefined>(obj1.optional);
     expectType<number | undefined>(obj1.union_undef);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -38,6 +40,7 @@ if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'require')) {
 
     expectType<number | undefined>(obj1.optional);
     expectType<number | undefined>(obj1.union_undef);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -57,6 +60,7 @@ if (hasOwnProp(obj1, 'optional')) {
 
     expectType<number>(obj1.require);
     expectType<number | undefined>(obj1.union_undef);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -71,6 +75,7 @@ if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'optional')) 
 
     expectType<number>(obj1.require);
     expectType<number | undefined>(obj1.union_undef);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -85,6 +90,7 @@ if (hasOwnProp(obj1, 'union_undef')) {
 
     expectType<number>(obj1.require);
     expectType<number | undefined>(obj1.optional);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -104,6 +110,7 @@ if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'union_undef'
 
     expectType<number>(obj1.require);
     expectType<number | undefined>(obj1.optional);
+    expectType<boolean | undefined>(obj1.optional_union_undef);
 } else {
     /**
      * The `hasOwnProperty()` method checks that the specified object has its own properties.
@@ -116,6 +123,48 @@ if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'union_undef'
      *       How to change `obj1` to any type except `never` in the `else` condition of a type guard
      */
     // expectType<number | undefined>(obj1.union_undef);
+}
+
+if (hasOwnProp(obj1, 'optional_union_undef')) {
+    expectType<boolean | undefined>(obj1.optional_union_undef);
+    expectAssignable<{
+        optional_union_undef: boolean | undefined;
+    }>(obj1);
+
+    expectType<number>(obj1.require);
+    expectType<number | undefined>(obj1.optional);
+    expectType<number | undefined>(obj1.union_undef);
+} else {
+    /**
+     * The `hasOwnProperty()` method checks that the specified object has its own properties.
+     * However, it does not check if it has any inherited properties.
+     * Even if the `hasOwnProperty()` method returns `false`, there is still a possibility that the specified object has the checked property.
+     */
+    expectType<boolean | undefined>(obj1.optional_union_undef);
+    expectNotAssignable<{
+        optional_union_undef: boolean | undefined;
+    }>(obj1);
+}
+
+if ((Object.prototype.hasOwnProperty.call as hasOwnProperty)(obj1, 'optional_union_undef')) {
+    expectType<boolean | undefined>(obj1.optional_union_undef);
+    expectAssignable<{
+        optional_union_undef: boolean | undefined;
+    }>(obj1);
+
+    expectType<number>(obj1.require);
+    expectType<number | undefined>(obj1.optional);
+    expectType<number | undefined>(obj1.union_undef);
+} else {
+    /**
+     * The `hasOwnProperty()` method checks that the specified object has its own properties.
+     * However, it does not check if it has any inherited properties.
+     * Even if the `hasOwnProperty()` method returns `false`, there is still a possibility that the specified object has the checked property.
+     */
+    expectType<boolean | undefined>(obj1.optional_union_undef);
+    expectNotAssignable<{
+        optional_union_undef: boolean | undefined;
+    }>(obj1);
 }
 
 if (hasOwnProp(obj1, 'nonExistent')) {


### PR DESCRIPTION
Starting from TypeScript 4.4, optional properties are not union types with `undefined` when [the `exactOptionalPropertyTypes` option](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes) is enabled.
Therefore, we add tests for optional properties with union types containing `undefined`.