### PR TITLE
test(encrypted-archive): monitor memory usage of sub-processes instead of test code

### DIFF
--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -109,6 +109,7 @@
     "combinate": "1.1.7",
     "cpy-cli": "3.1.1",
     "escape-string-regexp": "4.0.0",
+    "execa": "5.1.1",
     "glob-exec": "0.1.1",
     "grpc_tools_node_protoc_ts": "5.3.2",
     "jest": "27.3.1",

--- a/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
+++ b/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
@@ -23,6 +23,14 @@ let timerID;
   timerID = setImmediate(monitorMem);
 })();
 
+const buffer = new Uint8Array(500 * 2 ** 20);
+let bufferOffset = 0;
+
+process.stdin.on('data', data => {
+  data.copy(buffer, bufferOffset);
+  bufferOffset += data.byteLength;
+});
+
 pipeline(
   process.stdin,
   encryptStream(password, {

--- a/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
+++ b/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
@@ -23,14 +23,6 @@ let timerID;
   timerID = setImmediate(monitorMem);
 })();
 
-const buffer = new Uint8Array(500 * 2 ** 20);
-let bufferOffset = 0;
-
-process.stdin.on('data', data => {
-  data.copy(buffer, bufferOffset);
-  bufferOffset += data.byteLength;
-});
-
 pipeline(
   process.stdin,
   encryptStream(password, {

--- a/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
+++ b/packages/encrypted-archive/tests/stream/encrypt-and-decrypt-then-generate-sha1.cjs
@@ -1,0 +1,42 @@
+// @ts-check
+
+const { createHash } = require('crypto');
+const { pipeline } = require('stream');
+
+const { decryptStream, encryptStream } = require('../../dist');
+
+const password = '1234';
+const outputHash = createHash('sha1');
+
+const maxMemoryUsage = process.memoryUsage();
+
+/** @type {NodeJS.Immediate} */
+let timerID;
+(function monitorMem() {
+  const memoryUsage = process.memoryUsage();
+  maxMemoryUsage.rss = Math.max(maxMemoryUsage.rss, memoryUsage.rss);
+  maxMemoryUsage.heapTotal = Math.max(maxMemoryUsage.heapTotal, memoryUsage.heapTotal);
+  maxMemoryUsage.heapUsed = Math.max(maxMemoryUsage.heapUsed, memoryUsage.heapUsed);
+  maxMemoryUsage.external = Math.max(maxMemoryUsage.external, memoryUsage.external);
+  maxMemoryUsage.arrayBuffers = Math.max(maxMemoryUsage.arrayBuffers, memoryUsage.arrayBuffers);
+
+  timerID = setImmediate(monitorMem);
+})();
+
+pipeline(
+  process.stdin,
+  encryptStream(password, {
+    algorithm: 'aes-256-gcm',
+  }),
+  decryptStream(password),
+  outputHash,
+  err => {
+    clearImmediate(timerID);
+
+    if (err) throw err;
+    console.log(JSON.stringify({
+      maxMemoryUsage,
+      sha1: outputHash.digest('hex'),
+    }));
+  },
+);

--- a/packages/encrypted-archive/tests/stream/large-data.ts
+++ b/packages/encrypted-archive/tests/stream/large-data.ts
@@ -1,43 +1,48 @@
 import * as crypto from 'crypto';
+import * as path from 'path';
 
-import { decryptStream, encryptStream } from '../../src';
+import execa from 'execa';
+
 import { createFillBytesReadableStream, pipelineAsync } from '../helpers/stream';
 
-const password = '1234';
+const PACKAGE_ROOT = path.resolve(__dirname, '../..');
 
 describe('encryptStream()', () => {
+    beforeAll(async () => {
+        await execa('pnpm', ['run', 'build-with-cache'], { cwd: PACKAGE_ROOT });
+    }, 60 * 1000);
+
     it('transform large data', async () => {
         const dataSize = 500 * 2 ** 20; // 500 MiB
         const inputHash = crypto.createHash('sha1');
-        const outputHash = crypto.createHash('sha1');
         const inputStream = createFillBytesReadableStream({ size: dataSize });
 
-        const startMem = process.memoryUsage().rss;
+        const subprocessPath = path.resolve(__dirname, 'encrypt-and-decrypt-then-generate-sha1.cjs');
+        const subprocess = execa('node', [subprocessPath], { input: inputStream });
+
         await Promise.all([
-            pipelineAsync(
-                inputStream,
-                encryptStream(password, {
-                    algorithm: 'aes-256-gcm',
-                }),
-                decryptStream(password),
-                outputHash,
-            ),
+            subprocess,
             pipelineAsync(
                 inputStream,
                 inputHash,
             ),
         ]);
-        const endMem = process.memoryUsage().rss;
+        const subprocessResult = JSON.parse((await subprocess).stdout);
 
         /**
          * If Encryptor is using the Stream API correctly,
          * the amount of memory used will be less than the input data length
          * even when converting huge data.
          */
-        expect(endMem - startMem).toBeLessThanByteSize(dataSize);
+        const expectedMaxMemoryUsage = dataSize / 5;
+        expect(subprocessResult.maxMemoryUsage.rss).toBeLessThanByteSize(expectedMaxMemoryUsage);
+        expect(subprocessResult.maxMemoryUsage.heapTotal).toBeLessThanByteSize(expectedMaxMemoryUsage);
+        expect(subprocessResult.maxMemoryUsage.heapUsed).toBeLessThanByteSize(expectedMaxMemoryUsage);
+        expect(subprocessResult.maxMemoryUsage.external).toBeLessThanByteSize(expectedMaxMemoryUsage);
+        expect(subprocessResult.maxMemoryUsage.arrayBuffers).toBeLessThanByteSize(expectedMaxMemoryUsage);
 
         const inputSHA1 = inputHash.digest('hex');
-        const outputSha1 = outputHash.digest('hex');
+        const outputSha1 = subprocessResult.sha1;
         expect(outputSha1).toStrictEqual(inputSHA1);
     }, 10 * 60 * 1000);
 });

--- a/packages/encrypted-archive/tests/stream/large-data.ts
+++ b/packages/encrypted-archive/tests/stream/large-data.ts
@@ -34,7 +34,7 @@ describe('encryptStream()', () => {
          * the amount of memory used will be less than the input data length
          * even when converting huge data.
          */
-        const expectedMaxMemoryUsage = dataSize / 5;
+        const expectedMaxMemoryUsage = dataSize / 2;
         expect(subprocessResult.maxMemoryUsage.rss).toBeLessThanByteSize(expectedMaxMemoryUsage);
         expect(subprocessResult.maxMemoryUsage.heapTotal).toBeLessThanByteSize(expectedMaxMemoryUsage);
         expect(subprocessResult.maxMemoryUsage.heapUsed).toBeLessThanByteSize(expectedMaxMemoryUsage);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,7 @@ importers:
       combinate: 1.1.7
       cpy-cli: 3.1.1
       escape-string-regexp: 4.0.0
+      execa: 5.1.1
       glob-exec: 0.1.1
       google-protobuf: ^3.15.8
       grpc_tools_node_protoc_ts: 5.3.2
@@ -260,6 +261,7 @@ importers:
       combinate: 1.1.7
       cpy-cli: 3.1.1
       escape-string-regexp: 4.0.0
+      execa: 5.1.1
       glob-exec: 0.1.1
       grpc_tools_node_protoc_ts: 5.3.2
       jest: 27.3.1


### PR DESCRIPTION
When monitoring memory usage in the test code, the difference in memory usage may become negative due to garbage collection.
Also, Jest does not necessarily run each test in a different sub-process.

Therefore, we changed to run encryption and decryption in a sub-process and use the memory usage of the sub-process for testing.