### PR TITLE
chore(encrypted-archive): update tsconfig file structure

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -51,8 +51,19 @@ overrides:
     parserOptions:
       sourceType: module
       project:
-        - ./packages/{*,*/*}{,/tests{,/helpers},/test-d}/tsconfig.json
-        - ./actions/*{,/tests{,/helpers},/test-d}/tsconfig.json
+        - ./packages/{*,*/*}/src/tsconfig.json
+        - ./packages/{*,*/*}/tests/helpers/tsconfig.json
+        - ./packages/{*,*/*}/tests/tsconfig.json
+        - ./packages/{*,*/*}/test-d/tsconfig.json
+        - ./packages/{*,*/*}/tsconfig.json
+          # Note: The package root tsconfig must be written after the subdirectory of tsconfig.
+          #       Writing it before the subdirectory may cause erroneous errors
+          #       because ESLint will use the package root tsconfig before the subdirectory tsconfig.
+        - ./actions/*/src/tsconfig.json
+        - ./actions/*/tests/helpers/tsconfig.json
+        - ./actions/*/tests/tsconfig.json
+        - ./actions/*/test-d/tsconfig.json
+        - ./actions/*/tsconfig.json
     settings:
       node:
         # see https://github.com/mysticatea/eslint-plugin-node/blob/v11.1.0/docs/rules/shebang.md

--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -62,7 +62,8 @@
   },
   "files": [
     "dist/",
-    "runkit-example.js"
+    "runkit-example.js",
+    "!*.tsbuildinfo"
   ],
   "scripts": {
     "build": "run-p build:*",
@@ -75,9 +76,9 @@
     "build:copy-js-and-dts": "cpy '**/*.{js,d.ts}' ../dist/ --cwd=./src/ --parents",
     "build:docs": "run-p build:docs:*",
     "build:docs:bytefield": "glob-exec --foreach 'docs/**/*.edn' -- 'bytefield-svg --source {{file}} --output {{file.path.replace(/\\.\\w+$/, `.svg`)}}'",
-    "build:tsc": "tsc",
+    "build:tsc": "tsc -p ./src/",
     "lint:tsc": "run-p lint:tsc:*",
-    "lint:tsc:src": "tsc --noEmit",
+    "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
     "test": "run-if-supported --verbose run-p test:*",
     "test:examples": "run-s build-with-cache test:examples:*",

--- a/packages/encrypted-archive/src/tsconfig.json
+++ b/packages/encrypted-archive/src/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Modules */
+    // When the `composite` option is `true` and the `rootDir` option is undefined,
+    // files will not be created directly under the `outDir`
+    "rootDir": "./",
+    "types": ["node"],
+
+    /* Emit */
+    "declarationMap": false,
+    "outDir": "../dist",
+    "noEmit": false,
+    "inlineSources": true
+  },
+  "include": ["./**/*"]
+}

--- a/packages/encrypted-archive/tests/tsconfig.json
+++ b/packages/encrypted-archive/tests/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Modules */
-    "rootDir": "../",
     "types": [
       "node",
       "jest",
@@ -17,11 +16,7 @@
     "allowJs": true,
 
     /* Emit */
-    "noEmit": true,
-
-    /* Type Checking */
-    /** @todo Comment out when this package is fixed */
-    "useUnknownInCatchVariables": false
+    "noEmit": true
   },
   "include": ["./**/*", "../src/**/*", "../package.json"]
 }

--- a/packages/encrypted-archive/tsconfig.json
+++ b/packages/encrypted-archive/tsconfig.json
@@ -4,19 +4,14 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Modules */
-    // When the `composite` option is `true` and the `rootDir` option is undefined,
-    // files will not be created directly under the `outDir`
-    "rootDir": "./src",
-    "types": ["node"],
+    "rootDir": "./",
+    "types": [],
 
     /* Emit */
-    "declarationMap": false,
-    "outDir": "./dist",
-    "inlineSources": true,
+    "noEmit": true,
 
     /* Type Checking */
     /** @todo Comment out when this package is fixed */
     "useUnknownInCatchVariables": false
-  },
-  "include": ["./src/**/*"]
+  }
 }


### PR DESCRIPTION
Separated the `tsconfig.json` file for package root and `src` directory.

Before:
```
[package root]
├── tsconfig.json ... For building and type checking of `src` directory
└── tests
    └── tsconfig.json ... For type checking of test files
```

After:
```
[package root]
├── tsconfig.json ... For the base to define common options for all tsconfig files
├── src
│   └── tsconfig.json ... For building and type checking of source files
└── tests
    └── tsconfig.json ... For type checking of test files
```