### PR TITLE
fix(publish): fix `files` field in `package.json` files to ensure appropriate files are published

### DIFF
--- a/packages/check-pid-file/package.json
+++ b/packages/check-pid-file/package.json
@@ -32,7 +32,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "!*.tsbuildinfo"
+    "**/CHANGELOG.md",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "tsc -p ./src/",

--- a/packages/cli-utils/top-level-await-cli/package.json
+++ b/packages/cli-utils/top-level-await-cli/package.json
@@ -23,7 +23,8 @@
   "files": [
     "dist/",
     "src/",
-    "!*.tsbuildinfo",
+    "**/CHANGELOG.md",
+    "!**/*.tsbuildinfo",
     "!tsconfig.json"
   ],
   "scripts": {

--- a/packages/cli/run-if-supported/package.json
+++ b/packages/cli/run-if-supported/package.json
@@ -45,9 +45,10 @@
   },
   "files": [
     "dist/",
+    "**/CHANGELOG.md",
     "cli.js",
-    "!*.d.ts",
-    "!*.tsbuildinfo"
+    "!**/*.d.ts",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "tsc -p ./src/",

--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -62,8 +62,9 @@
   },
   "files": [
     "dist/",
+    "**/CHANGELOG.md",
     "runkit-example.js",
-    "!*.tsbuildinfo"
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "run-p build:*",

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -42,7 +42,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "!*.tsbuildinfo"
+    "**/CHANGELOG.md",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "tsc -p ./src/",

--- a/packages/stream-transform-from/package.json
+++ b/packages/stream-transform-from/package.json
@@ -65,6 +65,7 @@
   "files": [
     "dist/",
     "src/",
+    "**/CHANGELOG.md",
     "examples/index.js"
   ],
   "scripts": {

--- a/packages/ts-type-utils/has-own-property/package.json
+++ b/packages/ts-type-utils/has-own-property/package.json
@@ -25,6 +25,7 @@
   "author": "sounisi5011",
   "types": "./index.d.ts",
   "files": [
+    "**/CHANGELOG.md",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/ts-type-utils/is-readonly-array/package.json
+++ b/packages/ts-type-utils/is-readonly-array/package.json
@@ -27,6 +27,7 @@
   "author": "sounisi5011",
   "types": "./index.d.ts",
   "files": [
+    "**/CHANGELOG.md",
     "index.d.ts"
   ],
   "scripts": {

--- a/packages/ts-utils/is-property-accessible/package.json
+++ b/packages/ts-utils/is-property-accessible/package.json
@@ -56,7 +56,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "!*.tsbuildinfo"
+    "**/CHANGELOG.md",
+    "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "run-p build:*",


### PR DESCRIPTION
There is a difference between the file published by the `pnpm publish` command and the `npm publish` command.
For this reason, fixed the `files` field in `package.json` files.

+ Include `CHANGELOG.md` files
    The `npm publish` command will always be included, but the `pnpm publish` command will be excluded if not specified.
+ Don't include `*.tsbuildinfo` files
    The Glob pattern parsing of the `pnpm publish` command seems to be broken and will not exclude files in subdirectories unless globstar ( `**/...` ) is added.