### PR TITLE
chore: release @sounisi5011/ts-type-util-has-own-property 1.0.3

### DIFF
--- a/packages/ts-type-utils/has-own-property/CHANGELOG.md
+++ b/packages/ts-type-utils/has-own-property/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.1.1...ts-type-util-has-own-property-v1.1.2) (2021-12-09)
+### [1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.2...ts-type-util-has-own-property-v1.0.3) (2021-12-09)
 
 
 ### Bug Fixes

--- a/packages/ts-type-utils/has-own-property/CHANGELOG.md
+++ b/packages/ts-type-utils/has-own-property/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### [1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.1.1...ts-type-util-has-own-property-v1.1.2) (2021-12-09)
+
+
+### Bug Fixes
+
+* **publish:** fix glob pattern of including `CHANGELOG.md` in the `files` field of `package.json` files ([#315](https://www.github.com/sounisi5011/npm-packages/issues/315)) ([95a36db](https://www.github.com/sounisi5011/npm-packages/commit/95a36db45185784b37cdbf3843746b3e808d67b3))
+
 ### [1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.1...ts-type-util-has-own-property-v1.0.2) (2021-12-09)
 
 

--- a/packages/ts-type-utils/has-own-property/package.json
+++ b/packages/ts-type-utils/has-own-property/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sounisi5011/ts-type-util-has-own-property",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "Fix the type definition of the `Object.prototype.hasOwnProperty()` method",
   "keywords": [
     "hasOwnProperty",

--- a/packages/ts-type-utils/has-own-property/package.json
+++ b/packages/ts-type-utils/has-own-property/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sounisi5011/ts-type-util-has-own-property",
-  "version": "1.1.2",
+  "version": "1.0.3",
   "description": "Fix the type definition of the `Object.prototype.hasOwnProperty()` method",
   "keywords": [
     "hasOwnProperty",


### PR DESCRIPTION
### [1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.2...ts-type-util-has-own-property-v1.0.3) (2021-12-09)

### Bug Fixes

* **publish:** fix glob pattern of including `CHANGELOG.md` in the `files` field of `package.json` files ([#315](https://www.github.com/sounisi5011/npm-packages/issues/315)) ([95a36db](https://www.github.com/sounisi5011/npm-packages/commit/95a36db45185784b37cdbf3843746b3e808d67b3))
