### PR TITLE
ci: check rate limits for the GitHub API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://shogo82148.github.io/blog/2020/10/23/github-bot-using-actions/
+        # https://stackoverflow.com/a/59352240/4907315
+        # https://docs.github.com/ja/actions/learn-github-actions/workflow-commands-for-github-actions
         run: |
           RATE_LIMIT_JSON="$(gh api 'rate_limit')"
           for type in 'core' 'search' 'graphql' 'integration_manifest' 'source_import' 'code_scanning_upload' 'actions_runner_registration' 'scim' ; do
@@ -38,10 +40,11 @@ jobs:
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" != 0 ]; then
-            echo '::error::' "Rate limit reached. Please wait until $(date -r "$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")")"
+            core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
+            echo "::error title=Rate limit reached::Please wait until $(date -d "@${core_reset}")"
             exit 1
           elif [ "${core_remaining}" -gt 10 ]; then
-            echo '::warning::' "The rate limit is approaching: core.remaining=${core_remaining}"
+            echo "::warning title=Rate limit is approaching::remaining is ${core_remaining}"
           fi
   lint:
     needs: if-run-ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,12 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
-      # nothing
-      - run: ":"
+      - name: Check GitHub API rate limit
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://shogo82148.github.io/blog/2020/10/23/github-bot-using-actions/
+        run: gh api 'rate_limit'
   lint:
     needs: if-run-ci
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           RATE_LIMIT_JSON="$(gh api 'rate_limit')"
           for type in 'core' 'search' 'graphql' 'integration_manifest' 'source_import' 'code_scanning_upload' 'actions_runner_registration' 'scim' ; do
             echo '::group::' "${type}"
-            echo "$(echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}")"
+            echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
             echo '::endgroup::'
           done
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,14 @@ jobs:
             echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
             echo '::endgroup::'
           done
+
+          core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
+          if [ "${core_remaining}" != 0 ]; then
+            echo '::error::' "Rate limit reached. Please wait until $(date -r "$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")")"
+            exit 1
+          elif [ "${core_remaining}" -gt 10 ]; then
+            echo '::warning::' "The rate limit is approaching: core.remaining=${core_remaining}"
+          fi
   lint:
     needs: if-run-ci
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,10 +41,10 @@ jobs:
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" != 0 ]; then
             core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
-            echo "::error title=Rate limit reached::Please wait until $(date -d "@${core_reset}")"
+            echo "::error::Rate limit reached. Please wait until $(date "+%Y/%m/%d %T" -d "@${core_reset}")"
             exit 1
           elif [ "${core_remaining}" -gt 10 ]; then
-            echo "::warning title=Rate limit is approaching::remaining is ${core_remaining}"
+            echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"
           fi
   lint:
     needs: if-run-ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
             core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
             echo "::error::Rate limit reached. Please wait until $(date -ud "@${core_reset}" "+%Y/%m/%d %T %Z")"
             exit 1
-          elif [ "${core_remaining}" -gt 10 ]; then
+          elif [ "${core_remaining}" -lt 10 ]; then
             echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"
           fi
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # https://shogo82148.github.io/blog/2020/10/23/github-bot-using-actions/
-        run: gh api 'rate_limit'
+        run: |
+          RATE_LIMIT_JSON="$(gh api 'rate_limit')"
+          for type in 'core' 'search' 'graphql' 'integration_manifest' 'source_import' 'code_scanning_upload' 'actions_runner_registration' 'scim' ; do
+            echo '::group::' "${type}"
+            echo "$(echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}")"
+            echo '::endgroup::'
+          done
   lint:
     needs: if-run-ci
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,17 +31,20 @@ jobs:
         # https://stackoverflow.com/a/59352240/4907315
         # https://docs.github.com/ja/actions/learn-github-actions/workflow-commands-for-github-actions
         run: |
+          readonly DATE_FORMAT='+%Y/%m/%d %T %Z'
+
           RATE_LIMIT_JSON="$(gh api 'rate_limit')"
           for type in 'core' 'search' 'graphql' 'integration_manifest' 'source_import' 'code_scanning_upload' 'actions_runner_registration' 'scim' ; do
             echo '::group::' "${type}"
             echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
+            echo "::notice::Reset time is $(date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}")"
             echo '::endgroup::'
           done
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" == 0 ]; then
             core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
-            echo "::error::Rate limit reached. Please wait until $(date -ud "@${core_reset}" "+%Y/%m/%d %T %Z")"
+            echo "::error::Rate limit reached. Please wait until $(date -ud "@${core_reset}" "${DATE_FORMAT}")"
             exit 1
           elif [ "${core_remaining}" -lt 10 ]; then
             echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" != 0 ]; then
             core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
-            echo "::error::Rate limit reached. Please wait until $(date "+%Y/%m/%d %T" -d "@${core_reset}")"
+            echo "::error::Rate limit reached. Please wait until $(date -ud "@${core_reset}" "+%Y/%m/%d %T %Z")"
             exit 1
           elif [ "${core_remaining}" -gt 10 ]; then
             echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           done
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
-          if [ "${core_remaining}" != 0 ]; then
+          if [ "${core_remaining}" == 0 ]; then
             core_reset="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.reset")"
             echo "::error::Rate limit reached. Please wait until $(date -ud "@${core_reset}" "+%Y/%m/%d %T %Z")"
             exit 1


### PR DESCRIPTION
Occasionally, APIs invoked with the [`GITHUB_TOKEN` secret](https://docs.github.com/ja/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) reach the rate limit and fail.
In this case, we need to wait until the rate limit resets, but we do not know how long we should wait.
So, check the rate limit status of the API every time.