### PR TITLE
revert(deps): chore(deps): update googlecloudplatform/release-please-action action to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.submodules-finder.outputs.result)}}
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v3
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
           release-type: node


### PR DESCRIPTION
This reverts pr https://github.com/sounisi5011/npm-packages/pull/344 (commit 282e1546ae993b2b02f8e31ddd91ae0b105be627).
The release-please-action v3 does not work well due to a rate limit error from the GitHub API.