### PR TITLE
fix(ts-utils-is-property-accessible): add "types" import condition into `exports` field in `package.json`

### DIFF
--- a/packages/ts-utils/is-property-accessible/package.json
+++ b/packages/ts-utils/is-property-accessible/package.json
@@ -48,7 +48,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/ts-utils/is-property-accessible/package.json
+++ b/packages/ts-utils/is-property-accessible/package.json
@@ -47,9 +47,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
TypeScript 4.7.2 fails to find a type declaration if the `"types"` import condition does not exist.
The following error occurs:

    error TS7016: Could not find a declaration file for module '<package name>'.