### PR TITLE
feat(jest-binary-data-matchers): remove unnecessary dependencies: jest-matcher-utils

### DIFF
--- a/packages/jest-matchers/binary-data/jest.config.cjs
+++ b/packages/jest-matchers/binary-data/jest.config.cjs
@@ -7,9 +7,6 @@ module.exports = {
       tsconfig: '<rootDir>/tests/tsconfig.json',
     },
   },
-  setupFilesAfterEnv: [
-    './jest.setup.cjs',
-  ],
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.ts'],
   testPathIgnorePatterns: ['<rootDir>/tests/helpers/'],

--- a/packages/jest-matchers/binary-data/jest.setup.cjs
+++ b/packages/jest-matchers/binary-data/jest.setup.cjs
@@ -1,2 +1,0 @@
-// @ts-check
-process.env.FORCE_COLOR = '1';

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -51,7 +51,7 @@
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
     "test": "run-if-supported --verbose run-p test:*",
-    "test:jest": "jest"
+    "test:jest": "jest --colors"
   },
   "dependencies": {
     "@sounisi5011/ts-type-util-is-readonly-array": "workspace:^1.0.0",

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -51,7 +51,7 @@
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
     "test": "run-if-supported --verbose run-p test:*",
-    "test:jest": "jest --colors"
+    "test:jest": "jest --color=true"
   },
   "dependencies": {
     "@sounisi5011/ts-type-util-is-readonly-array": "workspace:^1.0.0",

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -51,7 +51,7 @@
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
     "test": "run-if-supported --verbose run-p test:*",
-    "test:jest": "jest --color=true"
+    "test:jest": "cross-env FORCE_COLOR=1 jest"
   },
   "dependencies": {
     "@sounisi5011/ts-type-util-is-readonly-array": "workspace:^1.0.0",
@@ -61,6 +61,7 @@
     "@sounisi5011/run-if-supported": "workspace:^1.0.0",
     "@types/jest": "27.5.1",
     "@types/node": "12.20.52",
+    "cross-env": "7.0.3",
     "jest": "28.1.0",
     "pretty-format": "28.1.0",
     "ts-jest": "28.0.3",

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -55,8 +55,7 @@
   },
   "dependencies": {
     "@sounisi5011/ts-type-util-is-readonly-array": "workspace:^1.0.0",
-    "jest-diff": "^28.0.0",
-    "jest-matcher-utils": "^27.3.1"
+    "jest-diff": "^28.0.0"
   },
   "devDependencies": {
     "@sounisi5011/run-if-supported": "workspace:^1.0.0",

--- a/packages/jest-matchers/binary-data/src/matchers.ts
+++ b/packages/jest-matchers/binary-data/src/matchers.ts
@@ -33,21 +33,16 @@ function createCompareByteSizeMatcher(
         const expectedByteLength = isBytesData(expected) ? expected.byteLength : expected;
         const receivedByteLength = isBytesData(received) ? received.byteLength : received;
 
-        return {
-            message: toMessageFn(() => [
-                this.utils.matcherHint(matcherName, undefined, undefined, options),
-                ``,
-                padTextColumns([
-                    [
-                        'Expected:',
-                        [isNot ? 'not' : '', operator],
-                        this.utils.EXPECTED_COLOR(byteSize(expectedByteLength)),
-                    ],
-                    ['Received:', '', this.utils.RECEIVED_COLOR(byteSize(receivedByteLength))],
-                ]),
+        const message = toMessageFn(() => [
+            this.utils.matcherHint(matcherName, undefined, undefined, options),
+            ``,
+            padTextColumns([
+                ['Expected:', [isNot ? 'not' : '', operator], this.utils.EXPECTED_COLOR(byteSize(expectedByteLength))],
+                ['Received:', '', this.utils.RECEIVED_COLOR(byteSize(receivedByteLength))],
             ]),
-            pass: passFn({ expected: expectedByteLength, received: receivedByteLength }),
-        };
+        ]);
+        const pass = passFn({ expected: expectedByteLength, received: receivedByteLength });
+        return { message, pass };
     };
 }
 

--- a/packages/jest-matchers/binary-data/src/matchers.ts
+++ b/packages/jest-matchers/binary-data/src/matchers.ts
@@ -1,8 +1,6 @@
-import { EXPECTED_COLOR, matcherHint, RECEIVED_COLOR } from 'jest-matcher-utils';
-import type { MatcherHintOptions } from 'jest-matcher-utils';
-
 import { BytesData, bytesEqual, byteSize, isBytesData, padTextColumns, toMessageFn } from './utils';
 import { ensureBytes, ensureByteSizeOrBytes, printBytesDiff } from './utils/jest';
+import type { MatcherHintOptions } from './utils/jest';
 
 function createCompareByteSizeMatcher(
     opts: {
@@ -31,17 +29,21 @@ function createCompareByteSizeMatcher(
             promise: this.promise,
         };
 
-        ensureByteSizeOrBytes(received, expected, matcherName, options);
+        ensureByteSizeOrBytes(this.utils, received, expected, matcherName, options);
         const expectedByteLength = isBytesData(expected) ? expected.byteLength : expected;
         const receivedByteLength = isBytesData(received) ? received.byteLength : received;
 
         return {
             message: toMessageFn(() => [
-                matcherHint(matcherName, undefined, undefined, options),
+                this.utils.matcherHint(matcherName, undefined, undefined, options),
                 ``,
                 padTextColumns([
-                    ['Expected:', [isNot ? 'not' : '', operator], EXPECTED_COLOR(byteSize(expectedByteLength))],
-                    ['Received:', '', RECEIVED_COLOR(byteSize(receivedByteLength))],
+                    [
+                        'Expected:',
+                        [isNot ? 'not' : '', operator],
+                        this.utils.EXPECTED_COLOR(byteSize(expectedByteLength)),
+                    ],
+                    ['Received:', '', this.utils.RECEIVED_COLOR(byteSize(receivedByteLength))],
                 ]),
             ]),
             pass: passFn({ expected: expectedByteLength, received: receivedByteLength }),
@@ -106,12 +108,12 @@ export function toBytesEqual(
         promise: this.promise,
     };
 
-    ensureBytes(received, expected, matcherName, options);
+    ensureBytes(this.utils, received, expected, matcherName, options);
     const pass = bytesEqual(expected, received);
     const message = toMessageFn(() => [
-        matcherHint(matcherName, undefined, undefined, options),
+        this.utils.matcherHint(matcherName, undefined, undefined, options),
         ``,
-        printBytesDiff(expected, received, {
+        printBytesDiff(this.utils, expected, received, {
             expectedLabel: 'Expected',
             receivedLabel: 'Received',
             expand: this.expand,

--- a/packages/jest-matchers/binary-data/src/utils/jest.ts
+++ b/packages/jest-matchers/binary-data/src/utils/jest.ts
@@ -38,13 +38,14 @@ function createEnsure<T>(opts: EnsureFuncPredicateOptions<T>): EnsureFunc<T> {
 
         const labelList: string[] = [];
         const specificList: string[] = [];
+        const { printWithType, printExpected, printReceived, EXPECTED_COLOR, RECEIVED_COLOR } = utils;
         if (!isValidActual) {
-            labelList.push(utils.RECEIVED_COLOR('received'));
-            specificList.push(utils.printWithType('Received', actual, utils.printReceived));
+            labelList.push(RECEIVED_COLOR('received'));
+            specificList.push(printWithType('Received', actual, printReceived));
         }
         if (!isValidExpected) {
-            labelList.push(utils.EXPECTED_COLOR('expected'));
-            specificList.push(utils.printWithType('Expected', expected, utils.printExpected));
+            labelList.push(EXPECTED_COLOR('expected'));
+            specificList.push(printWithType('Expected', expected, printExpected));
         }
 
         throw new Error(utils.matcherErrorMessage(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,14 +290,12 @@ importers:
       '@types/node': 12.20.52
       jest: 28.1.0
       jest-diff: ^28.0.0
-      jest-matcher-utils: ^27.3.1
       pretty-format: 28.1.0
       ts-jest: 28.0.3
       typescript: 4.7.2
     dependencies:
       '@sounisi5011/ts-type-util-is-readonly-array': link:../../ts-type-utils/is-readonly-array
       jest-diff: 28.1.0
-      jest-matcher-utils: 27.4.6
     devDependencies:
       '@sounisi5011/run-if-supported': link:../../cli/run-if-supported
       '@types/jest': 27.5.1
@@ -2607,6 +2605,7 @@ packages:
   /diff-sequences/27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /diff-sequences/28.0.2:
     resolution: {integrity: sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==}
@@ -4268,6 +4267,7 @@ packages:
       diff-sequences: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
+    dev: true
 
   /jest-diff/28.1.0:
     resolution: {integrity: sha512-8eFd3U3OkIKRtlasXfiAQfbovgFgRDb0Ngcs2E+FMeBZ4rUezqIaGjuyggJBp+llosQXNEWofk/Sz4Hr5gMUhA==}
@@ -4322,10 +4322,12 @@ packages:
   /jest-get-type/27.4.0:
     resolution: {integrity: sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /jest-get-type/27.5.1:
     resolution: {integrity: sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
 
   /jest-get-type/28.0.2:
     resolution: {integrity: sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==}
@@ -4366,6 +4368,7 @@ packages:
       jest-diff: 27.5.1
       jest-get-type: 27.4.0
       pretty-format: 27.5.1
+    dev: true
 
   /jest-matcher-utils/28.1.0:
     resolution: {integrity: sha512-onnax0n2uTLRQFKAjC7TuaxibrPSvZgKTcSCnNUz/tOjJ9UhxNm7ZmPpoQavmTDUjXvUQ8KesWk2/VdrxIFzTQ==}
@@ -5573,6 +5576,7 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+    dev: true
 
   /pretty-format/28.1.0:
     resolution: {integrity: sha512-79Z4wWOYCdvQkEoEuSlBhHJqWeZ8D8YRPiPctJFCtvuaClGpiwiQYSCUOE6IEKUbbFukKOTFIUAXE8N4EQTo1Q==}
@@ -5642,6 +5646,7 @@ packages:
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
 
   /react-is/18.1.0:
     resolution: {integrity: sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,7 @@ importers:
       '@sounisi5011/ts-type-util-is-readonly-array': workspace:^1.0.0
       '@types/jest': 27.5.1
       '@types/node': 12.20.52
+      cross-env: 7.0.3
       jest: 28.1.0
       jest-diff: ^28.0.0
       pretty-format: 28.1.0
@@ -300,6 +301,7 @@ importers:
       '@sounisi5011/run-if-supported': link:../../cli/run-if-supported
       '@types/jest': 27.5.1
       '@types/node': 12.20.52
+      cross-env: 7.0.3
       jest: 28.1.0_@types+node@12.20.52
       pretty-format: 28.1.0
       ts-jest: 28.0.3_fc81a27b80351b0ea93cc89cb3c5aa0b


### PR DESCRIPTION
[`this.utils` is injected into all the matchers](https://jestjs.io/docs/expect#thisutils). `this.utils` is almost equal to the exports from `jest-matcher-utils`. Therefore, no need to include `jest-matcher-utils` in the dependencies.