### PR TITLE
ci(github actions): show job results using job summary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,21 +38,23 @@ jobs:
           readonly DATE_FORMAT='+%Y/%m/%d %T %Z'
           readonly RATE_LIMIT_JSON="$(gh api 'rate_limit')"
 
-          echo '# GitHub API rate limit' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '<table><tr><th>Type</th><th>Reset time</th><th>Raw Response</th></tr>' >> $GITHUB_STEP_SUMMARY
-          echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
-            echo "<tr><th>${type}</th><td>" >> $GITHUB_STEP_SUMMARY
-            date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}" >> $GITHUB_STEP_SUMMARY
-            echo "</td><td><pre lang=json>" >> $GITHUB_STEP_SUMMARY
-            echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}" >> $GITHUB_STEP_SUMMARY
-            echo "</pre></td></tr>" >> $GITHUB_STEP_SUMMARY
-          done
-          echo '</table>' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '## Raw Response' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "<pre lang=json>${RATE_LIMIT_JSON}</pre>" >> $GITHUB_STEP_SUMMARY
+          {
+            echo '# GitHub API rate limit'
+            echo
+            echo '<table><tr><th>Type</th><th>Reset time</th><th>Raw Response</th></tr>'
+            echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
+              echo "<tr><th>${type}</th><td>"
+              date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}"
+              echo "</td><td><pre lang=json>"
+              echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
+              echo "</pre></td></tr>"
+            done
+            echo '</table>'
+            echo ''
+            echo '## Raw Response'
+            echo ''
+            echo "<pre lang=json>${RATE_LIMIT_JSON}</pre>"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" == 0 ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,16 +42,26 @@ jobs:
             echo '# GitHub API rate limit'
             echo
             echo '<table><tr><th>Type</th><th>Used</th><th>Remaining</th><th>Reset time</th><th>Raw Response</th></tr>'
-            echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
-              rate_limit_max="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.limit")"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
+            rate_limit_json_per_type="$(echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}")"
+            rate_limit_max="$(echo "${rate_limit_json_per_type}" | jq -r ".limit")"
+            rate_limit_reset_time="$(date -ud "@$(echo "${rate_limit_json_per_type}" | jq -r ".reset")" "${DATE_FORMAT}")"
+
+            echo '::group::' "${type}"
+            echo "${rate_limit_json_per_type}"
+            echo "::notice::Reset time is ${rate_limit_reset_time} ("${type}")"
+            echo '::endgroup::'
+
+            {
               echo "<tr><th>${type}</th>"
-              echo "<td>$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.used")/${rate_limit_max}</td>"
-              echo "<td>$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.remaining")/${rate_limit_max}</td><td>"
-              date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}"
-              echo "</td><td><details><pre lang=json>"
-              echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
-              echo "</pre></details></td></tr>"
-            done
+              echo "<td>$(echo "${rate_limit_json_per_type}" | jq -r ".used")/${rate_limit_max}</td>"
+              echo "<td>$(echo "${rate_limit_json_per_type}" | jq -r ".remaining")/${rate_limit_max}</td>"
+              echo "<td>${rate_limit_reset_time}</td>"
+              echo "<td><details><pre lang=json>${rate_limit_json_per_type}</pre></details></td></tr>"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          done
+          {
             echo '</table>'
             echo '<details><summary>Raw Response</summary><pre lang=json>'
             echo "${RATE_LIMIT_JSON}" | jq .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,16 +33,26 @@ jobs:
         # https://qiita.com/ryo0301/items/de8ce43fe61ede66f80a
         # https://stedolan.github.io/jq/manual/v1.6/#keys,keys_unsorted
         # https://qiita.com/richmikan@github/items/2aee77ae13bee2c648f4
+        # https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
         run: |
           readonly DATE_FORMAT='+%Y/%m/%d %T %Z'
+          readonly RATE_LIMIT_JSON="$(gh api 'rate_limit')"
 
-          RATE_LIMIT_JSON="$(gh api 'rate_limit')"
+          echo '# GitHub API rate limit' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '<table><tr><th>Type</th><th>Reset time</th><th>Raw Response</th></tr>' >> $GITHUB_STEP_SUMMARY
           echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
-            echo '::group::' "${type}"
-            echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
-            echo "::notice::Reset time is $(date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}")"
-            echo '::endgroup::'
+            echo "<tr><th>${type}</th><td>" >> $GITHUB_STEP_SUMMARY
+            date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}" >> $GITHUB_STEP_SUMMARY
+            echo "</td><td><pre lang=json>" >> $GITHUB_STEP_SUMMARY
+            echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}" >> $GITHUB_STEP_SUMMARY
+            echo "</pre></td></tr>" >> $GITHUB_STEP_SUMMARY
           done
+          echo '</table>' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '## Raw Response' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo "<pre lang=json>${RATE_LIMIT_JSON}</pre>" >> $GITHUB_STEP_SUMMARY
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"
           if [ "${core_remaining}" == 0 ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
 
             echo '::group::' "${type}"
             echo "${rate_limit_json_per_type}"
-            echo "::notice::Reset time is ${rate_limit_reset_time} ("${type}")"
+            echo "::notice::Reset time is ${rate_limit_reset_time} (${type})"
             echo '::endgroup::'
 
             {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,19 +41,21 @@ jobs:
           {
             echo '# GitHub API rate limit'
             echo
-            echo '<table><tr><th>Type</th><th>Reset time</th><th>Raw Response</th></tr>'
+            echo '<table><tr><th>Type</th><th>Used</th><th>Remaining</th><th>Reset time</th><th>Raw Response</th></tr>'
             echo "${RATE_LIMIT_JSON}" | jq -r '.resources | keys_unsorted[]' | while read -r type; do
-              echo "<tr><th>${type}</th><td>"
+              rate_limit_max="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.limit")"
+              echo "<tr><th>${type}</th>"
+              echo "<td>$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.used")/${rate_limit_max}</td>"
+              echo "<td>$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.remaining")/${rate_limit_max}</td><td>"
               date -ud "@$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.${type}.reset")" "${DATE_FORMAT}"
-              echo "</td><td><pre lang=json>"
+              echo "</td><td><details><pre lang=json>"
               echo "${RATE_LIMIT_JSON}" | jq ".resources.${type}"
-              echo "</pre></td></tr>"
+              echo "</pre></details></td></tr>"
             done
             echo '</table>'
-            echo ''
-            echo '## Raw Response'
-            echo ''
-            echo "<pre lang=json>${RATE_LIMIT_JSON}</pre>"
+            echo '<details><summary>Raw Response</summary><pre lang=json>'
+            echo "${RATE_LIMIT_JSON}" | jq .
+            echo '</pre></details>'
           } >> "${GITHUB_STEP_SUMMARY}"
 
           core_remaining="$(echo "${RATE_LIMIT_JSON}" | jq -r ".resources.core.remaining")"


### PR DESCRIPTION
Before I knew it, a new feature [job summary](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) had been added to GitHub Actions, so I decided to give it a try.