### PR TITLE
chore: support .cts and .mts file extensions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,8 +10,12 @@ exclude_patterns:
   - "**/jest.config.js"
   # Test files for tsd ( https://www.npmjs.com/package/tsd )
   - "**/*.test-d.ts"
+  - "**/*.test-d.cts"
+  - "**/*.test-d.mts"
   # Generated files by the FlatBuffers compiler
   - "**/flatbuffers/*_generated.ts"
+  - "**/flatbuffers/*_generated.cts"
+  - "**/flatbuffers/*_generated.mts"
   # Generated files by the Protocol Buffers compiler
   - "**/protocol-buffers/*_pb.js"
   - "**/protocol-buffers/*_pb.d.ts"
@@ -30,3 +34,5 @@ exclude_patterns:
   - "**/vendor/"
   - "**/*_test.go"
   - "**/*.d.ts"
+  - "**/*.d.cts"
+  - "**/*.d.mts"

--- a/.dprint-js.json
+++ b/.dprint-js.json
@@ -9,6 +9,8 @@
   "includes": ["**/*.js", "**/*.cjs", "**/*.mjs"],
   "excludes": [
     "**/flatbuffers/*_generated.ts",
+    "**/flatbuffers/*_generated.cts",
+    "**/flatbuffers/*_generated.mts",
     "**/protocol-buffers/*_pb.js",
     "**/protocol-buffers/*_pb.d.ts",
     "**/runkit-example.js",
@@ -16,6 +18,8 @@
     "**/node_modules/",
     "**/dist/",
     "/packages/ts-type-utils/**/*.js",
-    "/packages/ts-type-utils/**/*.d.ts"
+    "/packages/ts-type-utils/**/*.d.ts",
+    "/packages/ts-type-utils/**/*.d.cts",
+    "/packages/ts-type-utils/**/*.d.mts"
   ]
 }

--- a/.dprint.base.json
+++ b/.dprint.base.json
@@ -9,5 +9,5 @@
     "taggedTemplate.spaceBeforeLiteral": false,
     "typeAssertion.spaceBeforeExpression": false
   },
-  "plugins": ["https://plugins.dprint.dev/typescript-0.46.0.wasm"]
+  "plugins": ["https://plugins.dprint.dev/typescript-0.69.0.wasm"]
 }

--- a/.dprint.json
+++ b/.dprint.json
@@ -6,9 +6,11 @@
   "typescript": {
     "indentWidth": 4
   },
-  "includes": ["**/*.ts"],
+  "includes": ["**/*.ts", "**/*.mts", "**/*.cts"],
   "excludes": [
     "**/flatbuffers/*_generated.ts",
+    "**/flatbuffers/*_generated.cts",
+    "**/flatbuffers/*_generated.mts",
     "**/protocol-buffers/*_pb.js",
     "**/protocol-buffers/*_pb.d.ts",
     "**/runkit-example.js",
@@ -16,6 +18,8 @@
     "**/node_modules/",
     "**/dist/",
     "/packages/ts-type-utils/**/*.js",
-    "/packages/ts-type-utils/**/*.d.ts"
+    "/packages/ts-type-utils/**/*.d.ts",
+    "/packages/ts-type-utils/**/*.d.cts",
+    "/packages/ts-type-utils/**/*.d.mts"
   ]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 !.*
 **/flatbuffers/*_generated.ts
+**/flatbuffers/*_generated.cts
+**/flatbuffers/*_generated.mts
 **/protocol-buffers/*_pb.js
 **/protocol-buffers/*_pb.d.ts
 **/runkit-example.js
@@ -8,3 +10,5 @@ node_modules/
 dist/
 /packages/ts-type-utils/**/*.js
 /packages/ts-type-utils/**/*.d.ts
+/packages/ts-type-utils/**/*.d.cts
+/packages/ts-type-utils/**/*.d.mts

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -26,7 +26,7 @@ rules:
     - devDependencies:
         - "*"
         - ".*"
-        - "**/*.test-d.ts"
+        - "**/*.test-d.{ts,cts,mts}"
         - "**/tests/**"
   import/order:
     - error
@@ -58,13 +58,15 @@ overrides:
         - ignores:
             - modules
             - dynamicImport
-  - files: "*.ts"
+  - files: "*.{ts,cts,mts}"
     extends:
       - plugin:node/recommended-module
       - plugin:n/recommended-module
       - plugin:@typescript-eslint/recommended
       - plugin:import/typescript
-      - standard-with-typescript
+      # `eslint-config-standard-with-typescript@21.0.1` does not yet support `.cts` and `.mts` extensions.
+      # Therefore we use a rewritten configuration of eslint-config-standard-with-typescript.
+      - ./.eslintrc/fixed-standard-with-typescript.cjs
     parserOptions:
       # The `parserOptions.sourceType` is already defined within `plugin:n/recommended-module`.
       # However, it is written in case `eslint-plugin-n` makes destructive changes in the future.
@@ -90,6 +92,12 @@ overrides:
           src/**/*.ts:
             - ^src/(.+?)\.ts$
             - dist/$1.js
+          src/**/*.cts:
+            - ^src/(.+?)\.cts$
+            - dist/$1.cjs
+          src/**/*.mts:
+            - ^src/(.+?)\.mts$
+            - dist/$1.mjs
     rules:
       # The "@typescript-eslint/no-floating-promises" rule requires a void operator to be used as a statement.
       # see https://github.com/typescript-eslint/typescript-eslint/blob/v4.21.0/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -120,7 +128,7 @@ overrides:
       promise/no-callback-in-promise: off
       # The "@typescript-eslint/strict-boolean-expressions" rule is very strict and stressful.
       "@typescript-eslint/strict-boolean-expressions": off
-  - files: "*.d.ts"
+  - files: "*.d.{ts,cts,mts}"
     rules:
       # The "no-redeclare" rule does not support namespace and function declarations of the same name.
       # example:
@@ -132,8 +140,8 @@ overrides:
       # If someone forks a type definition created in this project, the type definition will not be available in older versions of TypeScript.
       "@typescript-eslint/prefer-ts-expect-error": off
   - files:
-      - "**/tests/*.ts"
-      - "**/tests/!(helpers!(?))*{,/**}/*.ts"
+      - "**/tests/*.{ts,cts,mts}"
+      - "**/tests/!(helpers!(?))*{,/**}/*.{ts,cts,mts}"
     extends:
       - plugin:jest/recommended
       - plugin:jest/style
@@ -158,6 +166,7 @@ overrides:
       - scripts/*.js
       - jest.config.base.cjs
       - "**/jest.config.{js,cjs}"
+      - .eslintrc/**/*.{js,cjs}
     rules:
       import/no-extraneous-dependencies:
         - error

--- a/.eslintrc/fixed-standard-with-typescript.cjs
+++ b/.eslintrc/fixed-standard-with-typescript.cjs
@@ -1,0 +1,26 @@
+// @ts-check
+const path = require('path');
+
+const config = require('eslint-config-standard-with-typescript');
+
+module.exports = {
+  ...config,
+  overrides: config.overrides.map(overrideConfig => ({
+    ...overrideConfig,
+    /**
+     * Add .mts and .cts in addition to the .ts extension
+     */
+    files: [overrideConfig.files]
+      .flat()
+      .map(file => {
+        if (/\.[cm]ts$/.test(file)) {
+          throw new Error(
+            `eslint-config-standard-with-typescript now supports TypeScript 4.7. This file '${
+              path.basename(__filename)
+            }' is no longer needed.`,
+          );
+        }
+        return file.replace(/\.ts$/, '.{ts,cts,mts}');
+      }),
+  })),
+};

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -132,7 +132,7 @@ module.exports = async filenames => {
     );
   }
 
-  const tsFiles = filenames.filter(extFilter('ts'));
+  const tsFiles = filenames.filter(extFilter('ts', 'cts', 'mts'));
   const jsFiles = filenames.filter(extFilter('js', 'cjs', 'mjs'));
 
   const tsOrJsFiles = [...tsFiles, ...jsFiles];
@@ -149,9 +149,9 @@ module.exports = async filenames => {
      */
     commands.push(eslintCommand);
     /**
-      * Next, format code with dprint.
-      * dprint removes the unneeded lines that ESLint did not remove.
-      */
+     * Next, format code with dprint.
+     * dprint removes the unneeded lines that ESLint did not remove.
+     */
     commands.push(
       ...(
         await Promise.all([
@@ -161,9 +161,9 @@ module.exports = async filenames => {
       ).flat(),
     );
     /**
-      * Finally, format code again with ESLint.
-      * The code formatted by dprint does not follow ESLint's rules, so the last step is to use ESLint to correct the code.
-      */
+     * Finally, format code again with ESLint.
+     * The code formatted by dprint does not follow ESLint's rules, so the last step is to use ESLint to correct the code.
+     */
     commands.push(eslintCommand);
   }
 

--- a/actions/monorepo-workspace-submodules-finder/types.node_modules/path-starts-with.d.ts
+++ b/actions/monorepo-workspace-submodules-finder/types.node_modules/path-starts-with.d.ts
@@ -11,7 +11,7 @@ interface Options {
      * //=> false
      * startsWith('foo/bar', 'FOO', {nocase: true});
      * //=> true
-    */
+     */
     readonly nocase?: boolean;
     /**
      * Allow partial matches.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fmt:readme:update-badge": "globby-exec node ./scripts/update-readme-badge/index.mjs '{{*/**/README.md}}'",
     "fmt:ts": "run-s fmt:ts:eslint fmt:ts:dprint fmt:ts:eslint",
     "fmt:ts:dprint": "dprint fmt -c ./.dprint.json",
-    "fmt:ts:eslint": "eslint --cache --report-unused-disable-directives --fix --ext .ts ./",
+    "fmt:ts:eslint": "eslint --cache --report-unused-disable-directives --fix --ext .ts,.cts,.mts ./",
     "fmt:xs": "npm-run-all fmt:xs:eslint --parallel fmt:{ts,js}:dprint fmt:xs:eslint",
     "fmt:xs:eslint": "run-s 'lint:eslint -- --fix'",
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
Added .cts and .mts file extensions to settings such as Linter and Formatter.

+ Added to ESLint settings:
    - `.eslintignore`
    - `.eslintrc.yaml`
    - `fmt:ts:eslint` npm-script in `package.json`
    - Add `.eslintrc/fixed-standard-with-typescript.cjs`
+ Added to dprint settings:
    - `.dprint.json`
    - `.dprint-js.json`
+ Added to lint-staged settings:
    - `.lintstagedrc.cjs`
+ Added to Code Climate settings:
    - `.codeclimate.yml`