### PR TITLE
chore: fix `scripts/fix-changelog.mjs`

### DIFF
--- a/actions/monorepo-workspace-submodules-finder/CHANGELOG.md
+++ b/actions/monorepo-workspace-submodules-finder/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.2.7](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.6...monorepo-workspace-submodules-finder-action-v1.2.7) (2022-06-20)</span>
+## [1.2.7](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.6...monorepo-workspace-submodules-finder-action-v1.2.7) (2022-06-20)
 
 ### Bug Fixes
 
@@ -18,7 +18,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.6](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.5...monorepo-workspace-submodules-finder-action-v1.2.6) (2022-06-17)</span>
+## [1.2.6](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.5...monorepo-workspace-submodules-finder-action-v1.2.6) (2022-06-17)
 
 ### Bug Fixes
 
@@ -42,7 +42,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.5](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.4...monorepo-workspace-submodules-finder-action-v1.2.5) (2022-06-05)</span>
+## [1.2.5](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.4...monorepo-workspace-submodules-finder-action-v1.2.5) (2022-06-05)
 
 ### Bug Fixes
 
@@ -62,7 +62,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.4](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.3...monorepo-workspace-submodules-finder-action-v1.2.4) (2022-05-28)</span>
+## [1.2.4](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.3...monorepo-workspace-submodules-finder-action-v1.2.4) (2022-05-28)
 
 ### Bug Fixes
 
@@ -95,7 +95,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.3](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.2...monorepo-workspace-submodules-finder-action-v1.2.3) (2022-01-07)</span>
+## [1.2.3](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.2...monorepo-workspace-submodules-finder-action-v1.2.3) (2022-01-07)
 
 ### Bug Fixes
 
@@ -121,7 +121,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.2](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.1...monorepo-workspace-submodules-finder-action-v1.2.2) (2021-12-05)</span>
+## [1.2.2](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.1...monorepo-workspace-submodules-finder-action-v1.2.2) (2021-12-05)
 
 ### Bug Fixes
 
@@ -143,7 +143,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.2.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.0...monorepo-workspace-submodules-finder-action-v1.2.1) (2021-11-05)</span>
+## [1.2.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.2.0...monorepo-workspace-submodules-finder-action-v1.2.1) (2021-11-05)
 
 ### Bug Fixes
 
@@ -207,7 +207,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.1.0...monorepo-workspace-submodules-finder-action-v1.1.1) (2021-05-26)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.1.0...monorepo-workspace-submodules-finder-action-v1.1.1) (2021-05-26)
 
 ### Bug Fixes
 
@@ -252,7 +252,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.0.0...monorepo-workspace-submodules-finder-action-v1.0.1) (2021-04-12)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/monorepo-workspace-submodules-finder-action-v1.0.0...monorepo-workspace-submodules-finder-action-v1.0.1) (2021-04-12)
 
 ### Bug Fixes
 

--- a/packages/check-pid-file/CHANGELOG.md
+++ b/packages/check-pid-file/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.1.1...check-pid-file-v1.1.2) (2022-05-28)</span>
+## [1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.1.1...check-pid-file-v1.1.2) (2022-05-28)
 
 ### Bug Fixes
 
@@ -29,7 +29,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.1.0...check-pid-file-v1.1.1) (2021-12-09)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.1.0...check-pid-file-v1.1.1) (2021-12-09)
 
 ### Bug Fixes
 
@@ -67,7 +67,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.0.0...check-pid-file-v1.0.1) (2021-11-27)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/check-pid-file-v1.0.0...check-pid-file-v1.0.1) (2021-11-27)
 
 ### Bug Fixes
 

--- a/packages/cli-utils/top-level-await-cli/CHANGELOG.md
+++ b/packages/cli-utils/top-level-await-cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.1.3](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.2...cli-utils-top-level-await-v1.1.3) (2022-05-28)</span>
+## [1.1.3](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.2...cli-utils-top-level-await-v1.1.3) (2022-05-28)
 
 ### Bug Fixes
 
@@ -25,7 +25,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.1...cli-utils-top-level-await-v1.1.2) (2021-12-09)</span>
+## [1.1.2](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.1...cli-utils-top-level-await-v1.1.2) (2021-12-09)
 
 ### Bug Fixes
 
@@ -40,7 +40,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.0...cli-utils-top-level-await-v1.1.1) (2021-12-09)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/cli-utils-top-level-await-v1.1.0...cli-utils-top-level-await-v1.1.1) (2021-12-09)
 
 ### Bug Fixes
 

--- a/packages/cli/run-if-supported/CHANGELOG.md
+++ b/packages/cli/run-if-supported/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.1.0...run-if-supported-v1.1.1) (2021-12-09)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.1.0...run-if-supported-v1.1.1) (2021-12-09)
 
 ### Bug Fixes
 
@@ -48,7 +48,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.5](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.4...run-if-supported-v1.0.5) (2021-11-05)</span>
+## [1.0.5](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.4...run-if-supported-v1.0.5) (2021-11-05)
 
 ### Bug Fixes
 
@@ -72,7 +72,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.4](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.3...run-if-supported-v1.0.4) (2021-07-05)</span>
+## [1.0.4](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.3...run-if-supported-v1.0.4) (2021-07-05)
 
 ### Bug Fixes
 
@@ -88,7 +88,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.2...run-if-supported-v1.0.3) (2021-06-24)</span>
+## [1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.2...run-if-supported-v1.0.3) (2021-06-24)
 
 ### Bug Fixes
 
@@ -104,7 +104,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.1...run-if-supported-v1.0.2) (2021-06-05)</span>
+## [1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.1...run-if-supported-v1.0.2) (2021-06-05)
 
 ### Bug Fixes
 
@@ -123,7 +123,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.0...run-if-supported-v1.0.1) (2021-05-28)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/run-if-supported-v1.0.0...run-if-supported-v1.0.1) (2021-05-28)
 
 ### Bug Fixes
 

--- a/packages/encrypted-archive/CHANGELOG.md
+++ b/packages/encrypted-archive/CHANGELOG.md
@@ -59,7 +59,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[0.0.4](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.3...encrypted-archive-v0.0.4) (2021-06-05)</span>
+## [0.0.4](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.3...encrypted-archive-v0.0.4) (2021-06-05)
 
 ### Bug Fixes
 
@@ -83,7 +83,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[0.0.3](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.2...encrypted-archive-v0.0.3) (2021-05-22)</span>
+## [0.0.3](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.2...encrypted-archive-v0.0.3) (2021-05-22)
 
 ### Bug Fixes
 
@@ -100,7 +100,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[0.0.2](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.1...encrypted-archive-v0.0.2) (2021-05-18)</span>
+## [0.0.2](https://www.github.com/sounisi5011/npm-packages/compare/encrypted-archive-v0.0.1...encrypted-archive-v0.0.2) (2021-05-18)
 
 ### Bug Fixes
 
@@ -115,7 +115,7 @@
 </details>
 
 
-## <span style="font-size:smaller">0.0.1 (2021-05-18)</span>
+## 0.0.1 (2021-05-18)
 
 ### Features
 

--- a/packages/jest-matchers/binary-data/CHANGELOG.md
+++ b/packages/jest-matchers/binary-data/CHANGELOG.md
@@ -36,7 +36,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/jest-binary-data-matchers-v1.1.0...jest-binary-data-matchers-v1.1.1) (2021-12-09)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/jest-binary-data-matchers-v1.1.0...jest-binary-data-matchers-v1.1.1) (2021-12-09)
 
 ### Bug Fixes
 

--- a/packages/stream-transform-from/CHANGELOG.md
+++ b/packages/stream-transform-from/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/stream-transform-from-v1.1.0...stream-transform-from-v1.1.1) (2022-05-28)</span>
+## [1.1.1](https://www.github.com/sounisi5011/npm-packages/compare/stream-transform-from-v1.1.0...stream-transform-from-v1.1.1) (2022-05-28)
 
 ### Bug Fixes
 

--- a/packages/ts-type-utils/has-own-property/CHANGELOG.md
+++ b/packages/ts-type-utils/has-own-property/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.2...ts-type-util-has-own-property-v1.0.3) (2021-12-09)</span>
+## [1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.2...ts-type-util-has-own-property-v1.0.3) (2021-12-09)
 
 ### Bug Fixes
 
@@ -16,7 +16,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.1...ts-type-util-has-own-property-v1.0.2) (2021-12-09)</span>
+## [1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.1...ts-type-util-has-own-property-v1.0.2) (2021-12-09)
 
 ### Bug Fixes
 
@@ -33,7 +33,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.0...ts-type-util-has-own-property-v1.0.1) (2021-11-27)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-has-own-property-v1.0.0...ts-type-util-has-own-property-v1.0.1) (2021-11-27)
 
 ### Bug Fixes
 

--- a/packages/ts-type-utils/is-readonly-array/CHANGELOG.md
+++ b/packages/ts-type-utils/is-readonly-array/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-is-readonly-array-v1.0.1...ts-type-util-is-readonly-array-v1.0.2) (2021-12-09)</span>
+## [1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-is-readonly-array-v1.0.1...ts-type-util-is-readonly-array-v1.0.2) (2021-12-09)
 
 ### Bug Fixes
 
@@ -16,7 +16,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-is-readonly-array-v1.0.0...ts-type-util-is-readonly-array-v1.0.1) (2021-12-09)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-type-util-is-readonly-array-v1.0.0...ts-type-util-is-readonly-array-v1.0.1) (2021-12-09)
 
 ### Bug Fixes
 

--- a/packages/ts-utils/is-property-accessible/CHANGELOG.md
+++ b/packages/ts-utils/is-property-accessible/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## <span style="font-size:smaller">[1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.2...ts-utils-is-property-accessible-v1.0.3) (2022-05-28)</span>
+## [1.0.3](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.2...ts-utils-is-property-accessible-v1.0.3) (2022-05-28)
 
 ### Bug Fixes
 
@@ -32,7 +32,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.1...ts-utils-is-property-accessible-v1.0.2) (2021-12-09)</span>
+## [1.0.2](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.1...ts-utils-is-property-accessible-v1.0.2) (2021-12-09)
 
 ### Bug Fixes
 
@@ -47,7 +47,7 @@
 </details>
 
 
-## <span style="font-size:smaller">[1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.0...ts-utils-is-property-accessible-v1.0.1) (2021-12-09)</span>
+## [1.0.1](https://www.github.com/sounisi5011/npm-packages/compare/ts-utils-is-property-accessible-v1.0.0...ts-utils-is-property-accessible-v1.0.1) (2021-12-09)
 
 ### Bug Fixes
 

--- a/scripts/fix-changelog.mjs
+++ b/scripts/fix-changelog.mjs
@@ -23,7 +23,7 @@ import { execa } from 'execa';
 const SEMVER_REGEXP = /[0-9]+(?:\.[0-9]+){2}(?:-[.0-9a-zA-Z-]+)?(?:\+[.0-9a-zA-Z-]+)?/;
 const VERSION_HEADING_REGEXP = new RegExp(
   String.raw
-    `\n+^(?<heading_level>###?) *(?<heading_text>(?:<(\w+)[^>]*>)?(?:(?<version1>${SEMVER_REGEXP.source})|\[(?<version2>${SEMVER_REGEXP.source})\]\([^)]+/compare/(?<base_ref>[^\s)]+?)\.{2,3}(?<head_ref>[^\s)]+?)\)) \([0-9]{4,}(?:-[0-9]{1,2}){2}\)(?:</\3>)?)$`,
+    `\n+^###? *(?:<(\w+)[^>]*>)?(?<heading_text>(?:${SEMVER_REGEXP.source}|\[${SEMVER_REGEXP.source}\]\([^)]+/compare/(?<base_ref>[^\s)]+?)\.{2,3}(?<head_ref>[^\s)]+?)\)) \([0-9]{4,}(?:-[0-9]{1,2}){2}\))(?:</\1>)?$`,
   'gm',
 );
 const COMMITS_SECTION_REGEXP = /^### *Commits$(?:\n(?!#)[^\n]*)*\n*/m;
@@ -169,24 +169,9 @@ async function fixChangelogSection(headingMatch, commitList, sectionRange) {
   const changelogText = headingMatch.input ?? '';
   const headingLine = headingMatch[0];
   const sectionBody = changelogText.substring(sectionRange.start + headingLine.length, sectionRange.end).trim();
-  const releaseVersion = headingMatch.groups?.version2 ?? headingMatch.groups?.version1 ?? '';
   const headingText = headingMatch.groups?.heading_text.trim() ?? '';
 
-  const isPatchUpdate = (
-    /^[0-9]+\.[0-9]+\.[1-9]/.test(releaseVersion)
-    || (headingMatch.groups?.heading_level.length ?? 0) >= 3
-  );
-  const smallerStyleTag = {
-    open: '<span style="font-size:smaller">',
-    close: '</span>',
-  };
-  const newHeadingLine = isPatchUpdate
-    ? `## ${smallerStyleTag.open}${
-      headingText.startsWith(smallerStyleTag.open) && headingText.endsWith(smallerStyleTag.close)
-        ? headingText.substring(smallerStyleTag.open.length, headingText.length - smallerStyleTag.close.length)
-        : headingText
-    }${smallerStyleTag.close}`
-    : `## ${headingText}`;
+  const newHeadingLine = `## ${headingText}`;
 
   const formattedSectionBody = sectionBody
     .replace(COMMITS_SECTION_REGEXP, '')


### PR DESCRIPTION
+ Fixed headings not wrapped in HTML tags because `release-please-action@v2` fails to parse.
+ Fixed `git log` command failure on GitHub Actions.