### PR TITLE
ci(unit test): run tests on Node.js x.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -303,14 +303,20 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 12.x
           - 12.17.0 # smallest version supported by pnpm v6 - https://github.com/pnpm/pnpm/releases/tag/v6.0.0
           - 12.20.0 # smallest version that supports ECMAScript modules - https://nodejs.org/api/esm.html#modules-ecmascript-modules
-          - 14.x
+          - 12.x
+          - 14.0.0
+          - 14.13.0 # smallest version that supports ECMAScript modules - https://nodejs.org/api/esm.html#modules-ecmascript-modules
           - 14.13.1 # smallest version that supports "node:" imports - https://nodejs.org/api/esm.html#node-imports
+          - 14.x
+          - 15.0.0
           - 15.x
+          - 16.0.0
           - 16.x
+          - 17.0.0
           - 17.x
+          - 18.0.0
           - 18.x
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The following versions have been added to the environment for running unit tests:
+ `14.0.0`
+ `14.13.0`
    This is the smallest version of ECMAScript modules supported.
    - https://nodejs.org/api/esm.html#modules-ecmascript-modules
+ `15.0.0`
+ `16.0.0`
+ `17.0.0`
+ `18.0.0`