### PR TITLE
ci(github actions): remove unnecessary `tags-ignore`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - "**"
-    tags-ignore:
-      - "**"
 jobs:
   if-run-ci:
     # see https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context


### PR DESCRIPTION
actionlint has reported the following mistake:

> "tags-ignore" filter is not available for pull_request event. it is only for push event