### PR TITLE
ci(unit tests): change the minimum version of Node.js 14 for running unit tests to 14.1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,7 +304,11 @@ jobs:
           - 12.17.0 # smallest version supported by pnpm v6 - https://github.com/pnpm/pnpm/releases/tag/v6.0.0
           - 12.20.0 # smallest version that supports ECMAScript modules - https://nodejs.org/api/esm.html#modules-ecmascript-modules
           - 12.x
-          - 14.0.0
+          - 14.1.0
+            # When trying install dependencies via pnpm in Node.js 14.0.0, pnpm throws the following error:
+            #   Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close
+            # This problem started occurring around 2022-06-27.
+            # It is probably an issue with the npm registry, as it also started occurring with older pnpm.
           - 14.13.0 # smallest version that supports ECMAScript modules - https://nodejs.org/api/esm.html#modules-ecmascript-modules
           - 14.13.1 # smallest version that supports "node:" imports - https://nodejs.org/api/esm.html#node-imports
           - 14.x


### PR DESCRIPTION
When trying install dependencies via pnpm in Node.js 14.0.0, pnpm throws the following error:

```
Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close
    at Source.onclose (internal/streams/end-of-stream.js:105:38)
    at Source.emit (events.js:315:20)
    at Extract.destroy (/opt/hostedtoolcache/node/14.0.0/x64/lib/node_modules/pnpm/dist/pnpm.cjs:71993:22)
    at Source.destroy (/opt/hostedtoolcache/node/14.0.0/x64/lib/node_modules/pnpm/dist/pnpm.cjs:71849:20)
    at Object.destroyer (internal/streams/destroy.js:166:59)
    at internal/streams/pipeline.js:58:19
    at internal/util.js:392:14
    at Source.<anonymous> (internal/streams/pipeline.js:84:7)
    at Source.<anonymous> (internal/util.js:392:14)
    at Source.onend (internal/streams/end-of-stream.js:95:49)
```

This problem started occurring around 2022-06-27.
It is probably an issue with the npm registry, as it also started occurring with older pnpm.