### PR TITLE
fix(protocol buffers): update protoc to v3.19.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,7 +230,7 @@ jobs:
       - name: Setup Protocol Buffers compiler
         uses: arduino/setup-protoc@v1
         with:
-          version: 3.15.8
+          version: 3.19.4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Show Protocol Buffers compiler version
         run: protoc --version

--- a/packages/encrypted-archive/src/header/protocol-buffers/header_pb.js
+++ b/packages/encrypted-archive/src/header/protocol-buffers/header_pb.js
@@ -13,7 +13,13 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var global = (function() {
+  if (this) { return this; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  if (typeof self !== 'undefined') { return self; }
+  return Function('return this')();
+}.call(null));
 
 goog.exportSymbol('proto.Argon2Options', null, global);
 goog.exportSymbol('proto.Argon2Options.Argon2Type', null, global);


### PR DESCRIPTION
This version is the latest protoc command currently available in Homebrew.
see https://formulae.brew.sh/formula/protobuf