### PR TITLE
ci(github actions): retry if formatting fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,9 @@ jobs:
           }
           echo '::endgroup::'
       - run: pnpm run build-only-packages
-      - run: pnpm run fmt
+      - # In rare cases, the "fmt" script may fail.
+        # In that case, it will try formatting again after 5 seconds.
+        run: pnpm run fmt || sleep 5 && pnpm run fmt
       - name: Check changes
         if: ${{ always() }}
         run: git diff --name-only --exit-code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,12 @@ jobs:
       - run: pnpm run build-only-packages
       - # In rare cases, the "fmt" script may fail.
         # In that case, it will try formatting again after 5 seconds.
-        run: pnpm run fmt || sleep 5 && pnpm run fmt
+        shell: bash
+        run: |
+          pnpm run fmt || {
+            sleep 5
+            pnpm run fmt
+          }
       - name: Check changes
         if: ${{ always() }}
         run: git diff --name-only --exit-code


### PR DESCRIPTION
In rare cases, the `pnpm run fmt` command may fail.
In that case, it will try formatting again after 5 seconds.