### PR TITLE
ci(lint-staged): output `lint-staged` logs in plain text on CI environment

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,9 @@
 # Note: This file should be POSIX compliant.
 #       If you edit this file, use "checkbashisms" to check it does not contain bash, zsh, or other features.
 
-./node_modules/.bin/lint-staged
+if [ -n "$CI" ]; then
+  # On CI, disable ANSI escapes and output plain text logs that are easy to read
+  ./node_modules/.bin/lint-staged | cat
+else
+  ./node_modules/.bin/lint-staged
+fi


### PR DESCRIPTION
lint-staged logs are moving text using ANSI escapes. However, in CI logs, the animated frames of text are concatenated, turning them into very difficult-to-read strings. Therefore, on the CI environment, we will disable ANSI escaping of lint-staged to output plain text logs.