### PR TITLE
ci(release): support manifest release output from `google-github-actions/release-please-action@v3`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -212,51 +212,58 @@ jobs:
         #       Execution by ultra-runner will fail.
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Update README
-        shell: bash
-        env:
-          # see https://obel.hatenablog.jp/entry/20220115/1642186800
-          DEBUG_STEPS_RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
+        # see https://dev.classmethod.jp/articles/github-actions-variable-indirection-reference/
         run: |
-          # TODO: Remove below code after fixing issue with "outputs.tag_name" being an empty string.
           tag_name='${{ steps.release.outputs.tag_name }}'
           if [ -z "${tag_name}" ]; then
-            echo '::error::outputs.tag_name is empty string'
-            echo '::group::JSON value of "steps.release.outputs"'
-            echo "${DEBUG_STEPS_RELEASE_OUTPUTS}"
-            echo '::endgroup::'
+            tag_name='${{ steps.release.outputs[format('{0}--tag_name', matrix.path-git-relative)] }}'
+          fi
+          if [ -z "${tag_name}" ]; then
             tag_name="$(git tag --points-at HEAD | tail -n 1)"
           fi
-          node ./scripts/publish-convert-readme.mjs "${tag_name}" '${{ matrix.path-git-relative }}/README.md'
 
-          #node ./scripts/publish-convert-readme.mjs '${{ steps.release.outputs.tag_name }}' '${{ matrix.path-git-relative }}/README.md'
+          node ./scripts/publish-convert-readme.mjs "${tag_name}" '${{ matrix.path-git-relative }}/README.md'
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          # see https://obel.hatenablog.jp/entry/20220115/1642186800
+          STEPS_RELEASE_OUTPUTS_JSON: ${{ toJson(steps.release.outputs) }}
+        # see https://dev.classmethod.jp/articles/github-actions-variable-indirection-reference/
         run: |
           readonly CUSTOM_PUBLISH_SCRIPT_PATH=.github/workflows/publish.sh
 
           cd '${{ matrix.path-git-relative }}'
           if [ -x "${CUSTOM_PUBLISH_SCRIPT_PATH}" ]; then
-            # TODO: Remove below code after fixing issue with "outputs.tag_name" being an empty string.
-            outputs_tag_name='${{ steps.release.outputs.tag_name }}'
-            if [ -z "${outputs_tag_name}" ]; then
-              outputs_tag_name="$(git tag --points-at HEAD | tail -n 1)"
-            fi
-
             export GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}'
             export matrix_package_name_with_scope='${{ matrix.package-name }}'
             export matrix_package_name_without_scope='${{ matrix.no-scope-package-name }}'
-            export outputs_upload_url='${{ steps.release.outputs.upload_url }}'
-            export outputs_html_url='${{ steps.release.outputs.html_url }}'
-            #export outputs_tag_name='${{ steps.release.outputs.tag_name }}'
-            export outputs_tag_name
-            export outputs_major='${{ steps.release.outputs.major }}'
-            export outputs_minor='${{ steps.release.outputs.minor }}'
-            export outputs_patch='${{ steps.release.outputs.patch }}'
-            export outputs_sha='${{ steps.release.outputs.sha }}'
-            export outputs_pr='${{ fromJson(steps.release.outputs.pr).number }}'
-            export outputs_pr_json='${{ steps.release.outputs.pr }}'
+
+            readonly normal_outputs_tag_name='${{ steps.release.outputs.tag_name }}'
+            readonly manifest_outputs_tag_name='${{ steps.release.outputs[format('{0}--tag_name', matrix.path-git-relative)] }}'
+            if [ -n "${normal_outputs_tag_name}" ]; then
+              export outputs_upload_url='${{ steps.release.outputs.upload_url }}'
+              export outputs_html_url='${{ steps.release.outputs.html_url }}'
+              export outputs_tag_name="${normal_outputs_tag_name}"
+              export outputs_major='${{ steps.release.outputs.major }}'
+              export outputs_minor='${{ steps.release.outputs.minor }}'
+              export outputs_patch='${{ steps.release.outputs.patch }}'
+              export outputs_sha='${{ steps.release.outputs.sha }}'
+            elif [ -n "${manifest_outputs_tag_name}" ]; then
+              export outputs_upload_url='${{ steps.release.outputs[format('{0}--upload_url', matrix.path-git-relative)] }}'
+              export outputs_html_url='${{ steps.release.outputs[format('{0}--html_url', matrix.path-git-relative)] }}'
+              export outputs_tag_name="${manifest_outputs_tag_name}"
+              export outputs_major='${{ steps.release.outputs[format('{0}--major', matrix.path-git-relative)] }}'
+              export outputs_minor='${{ steps.release.outputs[format('{0}--minor', matrix.path-git-relative)] }}'
+              export outputs_patch='${{ steps.release.outputs[format('{0}--patch', matrix.path-git-relative)] }}'
+              export outputs_sha='${{ steps.release.outputs[format('{0}--sha', matrix.path-git-relative)] }}'
+            else
+              echo '::group::JSON value of "steps.release.outputs"'
+              echo "${STEPS_RELEASE_OUTPUTS_JSON}"
+              echo '::endgroup::'
+              echo '::error::"steps.release.outputs" is data with unknown structure'
+            fi
+
             echo loading "${CUSTOM_PUBLISH_SCRIPT_PATH}"
             # shellcheck source=/dev/null
             source "${CUSTOM_PUBLISH_SCRIPT_PATH}"


### PR DESCRIPTION
[The output of `google-github-actions/release-please-action@v3`](https://github.com/sounisi5011/npm-packages/actions/runs/3819074265/jobs/6496458921#step:15:208) was [Manifest release output](https://github.com/google-github-actions/release-please-action/tree/v3.7.1#manifest-release-output).
Therefore, we changed to publish steps that also support manifest release output.