### PR TITLE
test(@sounisi5011/encrypted-archive): add missing tests

### DIFF
--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -78,7 +78,7 @@
     "build:docs": "concurrently 'pnpm:build~docs:*'",
     "build:tsc": "tsc -p ./src/",
     "build~docs:bytefield": "glob-exec --foreach 'docs/**/*.edn' -- 'bytefield-svg --source {{file}} --output {{file.path.replace(/\\.\\w+$/, `.svg`)}}'",
-    "lint:tsc": "pnpm run lint:tsc:src && pnpm run lint:tsc:test && lint:tsc:test-d",
+    "lint:tsc": "pnpm run lint:tsc:src && pnpm run lint:tsc:test && pnpm run lint:tsc:test-d",
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
     "lint:tsc:test-d": "pnpm run build-with-cache && tsc -p ./test-d/ --noEmit",

--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -78,12 +78,14 @@
     "build:docs": "concurrently 'pnpm:build~docs:*'",
     "build:tsc": "tsc -p ./src/",
     "build~docs:bytefield": "glob-exec --foreach 'docs/**/*.edn' -- 'bytefield-svg --source {{file}} --output {{file.path.replace(/\\.\\w+$/, `.svg`)}}'",
-    "lint:tsc": "pnpm run lint:tsc:src && pnpm run lint:tsc:test",
+    "lint:tsc": "pnpm run lint:tsc:src && pnpm run lint:tsc:test && lint:tsc:test-d",
     "lint:tsc:src": "tsc -p ./src/ --noEmit",
     "lint:tsc:test": "tsc -p ./tests/ --noEmit",
+    "lint:tsc:test-d": "pnpm run build-with-cache && tsc -p ./test-d/ --noEmit",
     "test": "run-if-supported --verbose concurrently --max-processes 1 'pnpm:test:*'",
     "test:examples": "pnpm build-with-cache && concurrently 'pnpm:test~examples:*'",
     "test:jest": "jest",
+    "test:tsd": "pnpm run build-with-cache && tsd",
     "test~examples:run": "glob-exec --foreach 'examples/*.js' -- 'echo \"$\" node {{file}}; node {{file}}; echo'"
   },
   "config": {
@@ -126,6 +128,7 @@
     "jest-extended": "3.0.0",
     "multicodec": "3.2.1",
     "semver": "7.3.7",
+    "tsd": "0.22.0",
     "typescript": "4.7.4",
     "ultra-runner": "3.10.5",
     "word-join": "0.0.1"

--- a/packages/encrypted-archive/test-d/public-api/types.test-d.ts
+++ b/packages/encrypted-archive/test-d/public-api/types.test-d.ts
@@ -1,0 +1,172 @@
+/* eslint-disable @typescript-eslint/no-invalid-void-type */
+
+import { expectAssignable, expectType } from 'tsd';
+
+import type {
+    CompressOptions,
+    CryptoAlgorithmName,
+    EncryptOptions,
+    InputDataType,
+    IteratorConverter,
+    KeyDerivationOptions,
+} from '../../dist/index.js';
+import { keyof } from '../utils.js';
+
+type TypedArray =
+    | Int8Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | Float32Array
+    | Float64Array
+    | BigInt64Array
+    | BigUint64Array;
+
+/**
+ * InputDataType
+ */
+
+declare const inputData:
+    | string
+    | Buffer
+    | TypedArray
+    | DataView
+    | ArrayBuffer
+    | SharedArrayBuffer;
+
+expectAssignable<InputDataType>(inputData);
+
+/**
+ * IteratorConverter
+ */
+
+declare const iteratorConverter: IteratorConverter;
+
+declare const source:
+    | Iterable<typeof inputData>
+    | AsyncIterable<typeof inputData>;
+iteratorConverter(source);
+
+void (async function*() {
+    const result = iteratorConverter(source);
+    expectAssignable<AsyncIterableIterator<Buffer>>(result);
+
+    const iterRes = await result.next();
+    if (!iterRes.done) expectType<Buffer>(iterRes.value);
+    for await (const chunk of result) {
+        expectType<Buffer>(chunk);
+    }
+
+    // return type is `void`
+    if (iterRes.done) expectType<void>(iterRes.value);
+    const ret = yield* result;
+    expectType<void>(ret);
+})();
+
+/**
+ * EncryptOptions
+ */
+
+// All properties are optional.
+expectAssignable<EncryptOptions>({});
+
+expectType<
+    | 'algorithm'
+    | 'keyDerivation'
+    | 'compress'
+>(keyof<EncryptOptions>());
+
+declare const encryptOptions: EncryptOptions;
+
+expectType<CryptoAlgorithmName | undefined>(encryptOptions.algorithm);
+// `undefined` can be specified
+expectAssignable<EncryptOptions>({ algorithm: undefined });
+
+expectType<KeyDerivationOptions | undefined>(encryptOptions.keyDerivation);
+// `undefined` can be specified
+expectAssignable<EncryptOptions>({ keyDerivation: undefined });
+
+expectType<CompressOptions | CompressOptions['algorithm'] | undefined>(encryptOptions.compress);
+// `undefined` can be specified
+expectAssignable<EncryptOptions>({ compress: undefined });
+
+/**
+ * CryptoAlgorithmName
+ */
+
+declare const cryptoAlgorithmName: CryptoAlgorithmName;
+
+expectType<
+    | 'aes-256-gcm'
+    | 'chacha20-poly1305'
+>(cryptoAlgorithmName);
+
+/**
+ * KeyDerivationOptions
+ */
+
+declare const keyDerivationOptions: KeyDerivationOptions;
+
+// check all supported key derivation functions
+expectType<
+    /**
+     * Argon2
+     */
+    | 'argon2d'
+    | 'argon2id'
+>(keyDerivationOptions.algorithm);
+
+// All option properties are optional.
+expectAssignable<KeyDerivationOptions>({
+    algorithm: keyDerivationOptions.algorithm,
+});
+
+/**
+ * Argon2 options
+ */
+if (
+    keyDerivationOptions.algorithm === 'argon2d'
+    || keyDerivationOptions.algorithm === 'argon2id'
+) {
+    const { algorithm } = keyDerivationOptions;
+
+    expectType<number | undefined>(keyDerivationOptions.iterations);
+    // `undefined` can be specified
+    expectAssignable<typeof keyDerivationOptions>({ iterations: undefined, algorithm });
+
+    expectType<number | undefined>(keyDerivationOptions.memory);
+    // `undefined` can be specified
+    expectAssignable<typeof keyDerivationOptions>({ memory: undefined, algorithm });
+
+    expectType<number | undefined>(keyDerivationOptions.parallelism);
+    // `undefined` can be specified
+    expectAssignable<typeof keyDerivationOptions>({ parallelism: undefined, algorithm });
+
+    expectType<
+        | 'algorithm'
+        | 'keyDerivation'
+        | 'compress'
+    >(keyof<EncryptOptions>());
+}
+
+/**
+ * CompressOptions
+ */
+
+declare const compressOptions: CompressOptions;
+
+// check all supported compression algorithms
+expectType<
+    | 'gzip'
+    | 'brotli'
+>(compressOptions.algorithm);
+
+// All option properties are optional.
+expectAssignable<CompressOptions>({
+    algorithm: compressOptions.algorithm,
+});
+
+/* eslint-enable */

--- a/packages/encrypted-archive/test-d/public-api/values.test-d.ts
+++ b/packages/encrypted-archive/test-d/public-api/values.test-d.ts
@@ -1,0 +1,54 @@
+import type * as stream from 'stream';
+
+import { expectType } from 'tsd';
+
+import type { EncryptOptions, InputDataType, IteratorConverter } from '../../dist/index.js';
+import { decrypt, decryptIterator, decryptStream, encrypt, encryptIterator, encryptStream } from '../../dist/index.js';
+import { keyof } from '../utils.js';
+
+// check all exported names
+expectType<
+    | 'encrypt'
+    | 'decrypt'
+    | 'encryptStream'
+    | 'decryptStream'
+    | 'encryptIterator'
+    | 'decryptIterator'
+>(keyof<typeof import('../../dist/index.js')>());
+
+expectType<
+    (
+        cleartext: InputDataType,
+        password: InputDataType,
+        options?: EncryptOptions,
+    ) => Promise<Buffer>
+>(encrypt);
+
+expectType<
+    (
+        encryptedData: InputDataType,
+        password: InputDataType,
+    ) => Promise<Buffer>
+>(decrypt);
+
+expectType<
+    (
+        password: InputDataType,
+        options?: EncryptOptions,
+    ) => stream.Transform
+>(encryptStream);
+
+expectType<
+    (password: InputDataType) => stream.Transform
+>(decryptStream);
+
+expectType<
+    (
+        password: InputDataType,
+        options?: EncryptOptions,
+    ) => IteratorConverter
+>(encryptIterator);
+
+expectType<
+    (password: InputDataType) => IteratorConverter
+>(decryptIterator);

--- a/packages/encrypted-archive/test-d/tsconfig.json
+++ b/packages/encrypted-archive/test-d/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Modules */
+    // Enable top-level await
+    "module": "ESNext",
+
+    /* Emit */
+    "noEmit": true
+  },
+  "include": ["./**/*"]
+}

--- a/packages/encrypted-archive/test-d/utils.ts
+++ b/packages/encrypted-archive/test-d/utils.ts
@@ -1,0 +1,1 @@
+export declare function keyof<T>(value?: T): keyof T;

--- a/packages/encrypted-archive/tests/public-api.ts
+++ b/packages/encrypted-archive/tests/public-api.ts
@@ -499,6 +499,18 @@ describe('should support encryption algorithms', () => {
             );
         });
     });
+    describe('invalid type algorithm', () => {
+        it.each(apiCases.encrypt.withCleartextChunk)('%s', async (_, encryptFn) => {
+            const options: EncryptOptions = {
+                // @ts-expect-error TS2322: Type 'number' is not assignable to type '"aes-256-gcm" | "chacha20-poly1305" | undefined'.
+                algorithm: 42,
+            };
+            await expect(encryptFn({ password: '', options })).rejects.toThrowWithMessage(
+                TypeError,
+                `Unknown algorithm was received: 42`,
+            );
+        });
+    });
 });
 
 describe('should support key derivation functions', () => {
@@ -530,6 +542,32 @@ describe('should support key derivation functions', () => {
             );
         });
     });
+    describe('invalid type', () => {
+        it.each(apiCases.encrypt.withCleartextChunk)('%s', async (_, encryptFn) => {
+            const options: EncryptOptions = {
+                // @ts-expect-error TS2322: Type 'number' is not assignable to type 'Argon2Options'.
+                keyDerivation: 42,
+            };
+            await expect(encryptFn({ password: '', options })).rejects.toThrowWithMessage(
+                TypeError,
+                `Unknown deriveKey options was received: 42`,
+            );
+        });
+    });
+    describe('invalid type algorithm', () => {
+        it.each(apiCases.encrypt.withCleartextChunk)('%s', async (_, encryptFn) => {
+            const options: EncryptOptions = {
+                keyDerivation: {
+                    // @ts-expect-error TS2322: Type 'number' is not assignable to type '"argon2d" | "argon2id"'.
+                    algorithm: 42,
+                },
+            };
+            await expect(encryptFn({ password: '', options })).rejects.toThrowWithMessage(
+                TypeError,
+                `Unknown KDF (Key Derivation Function) algorithm was received: 42`,
+            );
+        });
+    });
 });
 
 describe('should support compression algorithms', () => {
@@ -557,6 +595,18 @@ describe('should support compression algorithms', () => {
             await expect(encryptFn({ password: '', options })).rejects.toThrowWithMessage(
                 TypeError,
                 `Unknown compress algorithm was received: hoge`,
+            );
+        });
+    });
+    describe('invalid type', () => {
+        it.each(apiCases.encrypt.withCleartextChunk)('%s', async (_, encryptFn) => {
+            const options: EncryptOptions = {
+                // @ts-expect-error TS2322: Type 'number' is not assignable to type '"gzip" | "brotli" | CompressOptions | undefined'.
+                compress: 42,
+            };
+            await expect(encryptFn({ password: '', options })).rejects.toThrowWithMessage(
+                TypeError,
+                `Unknown compress algorithm was received: 42`,
             );
         });
     });

--- a/packages/encrypted-archive/tests/unit/compress.ts
+++ b/packages/encrypted-archive/tests/unit/compress.ts
@@ -43,6 +43,20 @@ describe('createCompressor()', () => {
         );
     });
 
+    describe('invalid type options', () => {
+        it.each<[unknown]>([
+            [42],
+            [{ algorithm: 42 }],
+        ])('%o', invalidAlgorithm => {
+            // @ts-expect-error TS2322: Type 'unknown' is not assignable to type '"gzip" | "brotli" | CompressOptions | undefined'.
+            const algorithm: Parameters<typeof createCompressor>[0] = invalidAlgorithm;
+            expect(() => createCompressor(algorithm)).toThrowWithMessage(
+                TypeError,
+                `Unknown compress algorithm was received: 42`,
+            );
+        });
+    });
+
     describe('not allowed options', () => {
         describe('gzip', () => {
             const algorithm = 'gzip';

--- a/packages/encrypted-archive/tests/unit/key-derivation-function.ts
+++ b/packages/encrypted-archive/tests/unit/key-derivation-function.ts
@@ -95,6 +95,10 @@ describe('algorithm: Argon2', () => {
     const ARGON2_MIN_TIME = 1;
     /** @see https://github.com/P-H-C/phc-winner-argon2/blob/16d3df698db2486dde480b09a732bf9bf48599f9/include/argon2.h#L72 */
     const ARGON2_MAX_TIME = 0xFFFFFFFF;
+    /** @see https://github.com/P-H-C/phc-winner-argon2/blob/16d3df698db2486dde480b09a732bf9bf48599f9/include/argon2.h#L75 */
+    const ARGON2_MIN_PWD_LENGTH = 0;
+    /** @see https://github.com/P-H-C/phc-winner-argon2/blob/16d3df698db2486dde480b09a732bf9bf48599f9/include/argon2.h#L76 */
+    const ARGON2_MAX_PWD_LENGTH = 0xFFFFFFFF;
     /** @see https://github.com/P-H-C/phc-winner-argon2/blob/16d3df698db2486dde480b09a732bf9bf48599f9/include/argon2.h#L83 */
     const ARGON2_MIN_SALT_LENGTH = 8;
     /** @see https://github.com/P-H-C/phc-winner-argon2/blob/16d3df698db2486dde480b09a732bf9bf48599f9/include/argon2.h#L84 */
@@ -311,6 +315,24 @@ describe('algorithm: Argon2', () => {
             });
         });
         describe('too long', () => {
+            it('password length', async () => {
+                const { deriveKey, saltLength } = getKDF({ algorithm: 'argon2d' });
+                const salt = Buffer.alloc(saltLength);
+                const passwordLengthBytes = ARGON2_MAX_PWD_LENGTH + 1;
+                const password = createDummySizeBuffer(passwordLengthBytes);
+                await expect(deriveKey(password, salt, safeKeyLengthBytes)).rejects.toThrowWithMessage(
+                    RangeError,
+                    [
+                        `Too long password was received for Argon2's option "password"`,
+                        `${
+                            notBetweenNumberErrorMessage(
+                                `Password length`,
+                                { min: ARGON2_MIN_PWD_LENGTH, max: ARGON2_MAX_PWD_LENGTH },
+                            )
+                        }, but received: ${passwordLengthBytes}`,
+                    ].join('. '),
+                );
+            });
             it('salt length', async () => {
                 const { deriveKey } = getKDF({ algorithm: 'argon2d' });
                 const saltLength = ARGON2_MAX_SALT_LENGTH + 1;

--- a/packages/encrypted-archive/tests/unit/key-derivation-function.ts
+++ b/packages/encrypted-archive/tests/unit/key-derivation-function.ts
@@ -38,6 +38,17 @@ describe('getKDF()', () => {
         );
     });
 
+    it('invalid type algorithm', () => {
+        const algorithm = 42;
+        // @ts-expect-error TS2322: Type 'number' is not assignable to type '"argon2d" | "argon2id"'.
+        const options: KeyDerivationOptions = { algorithm };
+
+        expect(() => getKDF(options)).toThrowWithMessage(
+            TypeError,
+            `Unknown KDF (Key Derivation Function) algorithm was received: ${algorithm}`,
+        );
+    });
+
     describe('invalid options', () => {
         it.each<unknown>([
             null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,7 @@ importers:
       jest-extended: 3.0.0
       multicodec: 3.2.1
       semver: 7.3.7
+      tsd: 0.22.0
       typescript: 4.7.4
       ultra-runner: 3.10.5
       varint: ^6.0.0
@@ -301,6 +302,7 @@ importers:
       jest-extended: 3.0.0_jest@28.1.3
       multicodec: 3.2.1
       semver: 7.3.7
+      tsd: 0.22.0
       typescript: 4.7.4
       ultra-runner: 3.10.5
       word-join: 0.0.1


### PR DESCRIPTION
During our work at https://github.com/sounisi5011/npm-packages/pull/542 we found that some tests were missing again.
In this PR, we will add the necessary tests. 

- Encryption algorithm
    - [x] Check that all algorithms work
    - [x] Check for throwing errors if the wrong `algorithm` is specified
    - [x] Check for throwing errors if the wrong type `algorithm` is specified
- Key derivation function
    - [x] Check that all algorithms work
    - [x] Check for throwing errors if the wrong `algorithm` is specified
    - [x] Check for throwing errors if the wrong type `algorithm` is specified
    - Argon2
        - [x] Check for throwing errors if the wrong type `iterations` option is specified
        - [x] Check for throwing errors if the wrong range `iterations` option is specified
        - [x] Check for throwing errors if the wrong type `memory` option is specified
        - [x] Check for throwing errors if the wrong range `memory` option is specified
        - [x] Check for throwing errors if the wrong type `parallelism` option is specified
        - [x] Check for throwing errors if the wrong range `parallelism` option is specified
        - ~~Check for throwing errors if the wrong type `password` option is specified~~
            value is not validated
        - [x] Check for throwing errors if the wrong length `password` option is specified
        - ~~Check for throwing errors if the wrong type `salt` option is specified~~
            value is not validated
        - [x] Check for throwing errors if the wrong length `salt` option is specified
        - ~~Check for throwing errors if the wrong type `keyLengthBytes` option is specified~~
            value is not validated
        - [x] Check for throwing errors if the wrong range `keyLengthBytes` option is specified
- Compression algorithm
    - [x] Check that all algorithms work
    - [x] Check for throwing errors if the wrong `algorithm` is specified
    - [x] Check for throwing errors if the wrong type `algorithm` is specified
    - [x] Check for throwing errors if the disallowed option is specified
- Type definition
    - [x] Check all types are exported
        - [x] `CompressOptions`
        - [x] `CryptoAlgorithmName`
        - [x] `EncryptOptions`
        - [x] `InputDataType`
        - [x] `IteratorConverter`
        - [x] `KeyDerivationOptions`
        - [x] `encrypt()`
        - [x] `decrypt()`
        - [x] `encryptStream()`
        - [x] `decryptStream()`
        - [x] `encryptIterator()`
        - [x] `decryptIterator()`
