### PR TITLE
ci(github action): revert `google-github-actions/release-please-action` to previous version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,29 @@ jobs:
             # The "token" parameter is optional.
             # However, it may cause an error due to the rate limit of GitHub API.
             # Therefore, it should be specified explicitly.
+      - name: Check release-please-action outputs
+        if: ${{ always() }}
+        env:
+          # see https://obel.hatenablog.jp/entry/20220115/1642186800
+          STEPS_RELEASE_OUTPUTS_JSON: ${{ toJson(steps.release.outputs) }}
+        run: |
+          echo '::group::JSON value of "steps.release.outputs"'
+          echo "${STEPS_RELEASE_OUTPUTS_JSON}"
+          echo '::endgroup::'
+      - name: Check GitHub API rate limit
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RATE_LIMIT_JSON="$(gh api 'rate_limit')"
+          readonly RATE_LIMIT_JSON
+
+          echo '::group::RATE_LIMIT_JSON'
+          echo "${RATE_LIMIT_JSON}" | jq
+          echo '::endgroup::'
+          echo '::group::core and graphql'
+          echo "${RATE_LIMIT_JSON}" | jq -r '.resources | [.core, .graphql]'
+          echo '::endgroup::'
 
         #
         # Commit to PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.submodules-finder.outputs.result)}}
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v2
         id: release
         with:
           release-type: node
@@ -73,24 +73,34 @@ jobs:
             # The "token" parameter is optional.
             # However, it may cause an error due to the rate limit of GitHub API.
             # Therefore, it should be specified explicitly.
-          pull-request-title-pattern: "chore: release${component} ${version}"
 
         #
         # Commit to PR
         #
+      - name: Commit to Release PR / Get PR ref
+        id: release-pr
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://shogo82148.github.io/blog/2020/10/23/github-bot-using-actions/
+        run: |
+          PULL_REQUEST="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ steps.release.outputs.pr }}")"
+          ref="$(echo "${PULL_REQUEST}" | jq -r '.head.ref')"
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
       - name: Commit to Release PR / Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ steps.release-pr.outputs.ref }}
           token: ${{ secrets.TRIGGER_TEST_GITHUB_TOKEN }}
           # All commit logs are required to update CHANGELOG.md by scripts/fix-changelog.mjs
           fetch-depth: 0
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Cache .pnpm-store
         uses: actions/cache@v3
         with:
@@ -100,13 +110,13 @@ jobs:
             ${{ runner.os }}-node-16.x-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Setup pnpm
         uses: ./actions/setup-pnpm
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Install Dependencies
         run: pnpm install
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Push to PR
         shell: bash
         # https://qiita.com/kawaz/items/1b61ee2dd4d1acc7cc94
@@ -166,7 +176,7 @@ jobs:
           echo '::group::$' git push
                             git push
           echo '::endgroup::'
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ steps.release-pr.outputs.ref }}
 
         #
         # Publish
@@ -212,24 +222,12 @@ jobs:
         #       Execution by ultra-runner will fail.
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Update README
-        # see https://dev.classmethod.jp/articles/github-actions-variable-indirection-reference/
         run: |
-          tag_name='${{ steps.release.outputs.tag_name }}'
-          if [ -z "${tag_name}" ]; then
-            tag_name='${{ steps.release.outputs[format('{0}--tag_name', matrix.path-git-relative)] }}'
-          fi
-          if [ -z "${tag_name}" ]; then
-            tag_name="$(git tag --points-at HEAD | tail -n 1)"
-          fi
-
-          node ./scripts/publish-convert-readme.mjs "${tag_name}" '${{ matrix.path-git-relative }}/README.md'
+          node ./scripts/publish-convert-readme.mjs '${{ steps.release.outputs.tag_name }}' '${{ matrix.path-git-relative }}/README.md'
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          # see https://obel.hatenablog.jp/entry/20220115/1642186800
-          STEPS_RELEASE_OUTPUTS_JSON: ${{ toJson(steps.release.outputs) }}
-        # see https://dev.classmethod.jp/articles/github-actions-variable-indirection-reference/
         run: |
           readonly CUSTOM_PUBLISH_SCRIPT_PATH=.github/workflows/publish.sh
 
@@ -238,32 +236,14 @@ jobs:
             export GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}'
             export matrix_package_name_with_scope='${{ matrix.package-name }}'
             export matrix_package_name_without_scope='${{ matrix.no-scope-package-name }}'
-
-            readonly normal_outputs_tag_name='${{ steps.release.outputs.tag_name }}'
-            readonly manifest_outputs_tag_name='${{ steps.release.outputs[format('{0}--tag_name', matrix.path-git-relative)] }}'
-            if [ -n "${normal_outputs_tag_name}" ]; then
-              export outputs_upload_url='${{ steps.release.outputs.upload_url }}'
-              export outputs_html_url='${{ steps.release.outputs.html_url }}'
-              export outputs_tag_name="${normal_outputs_tag_name}"
-              export outputs_major='${{ steps.release.outputs.major }}'
-              export outputs_minor='${{ steps.release.outputs.minor }}'
-              export outputs_patch='${{ steps.release.outputs.patch }}'
-              export outputs_sha='${{ steps.release.outputs.sha }}'
-            elif [ -n "${manifest_outputs_tag_name}" ]; then
-              export outputs_upload_url='${{ steps.release.outputs[format('{0}--upload_url', matrix.path-git-relative)] }}'
-              export outputs_html_url='${{ steps.release.outputs[format('{0}--html_url', matrix.path-git-relative)] }}'
-              export outputs_tag_name="${manifest_outputs_tag_name}"
-              export outputs_major='${{ steps.release.outputs[format('{0}--major', matrix.path-git-relative)] }}'
-              export outputs_minor='${{ steps.release.outputs[format('{0}--minor', matrix.path-git-relative)] }}'
-              export outputs_patch='${{ steps.release.outputs[format('{0}--patch', matrix.path-git-relative)] }}'
-              export outputs_sha='${{ steps.release.outputs[format('{0}--sha', matrix.path-git-relative)] }}'
-            else
-              echo '::group::JSON value of "steps.release.outputs"'
-              echo "${STEPS_RELEASE_OUTPUTS_JSON}"
-              echo '::endgroup::'
-              echo '::error::"steps.release.outputs" is data with unknown structure'
-            fi
-
+            export outputs_upload_url='${{ steps.release.outputs.upload_url }}'
+            export outputs_html_url='${{ steps.release.outputs.html_url }}'
+            export outputs_tag_name='${{ steps.release.outputs.tag_name }}'
+            export outputs_major='${{ steps.release.outputs.major }}'
+            export outputs_minor='${{ steps.release.outputs.minor }}'
+            export outputs_patch='${{ steps.release.outputs.patch }}'
+            export outputs_sha='${{ steps.release.outputs.sha }}'
+            export outputs_pr='${{ steps.release.outputs.pr }}'
             echo loading "${CUSTOM_PUBLISH_SCRIPT_PATH}"
             # shellcheck source=/dev/null
             source "${CUSTOM_PUBLISH_SCRIPT_PATH}"


### PR DESCRIPTION
`google-github-actions/release-please-action@v3` is now throwing rate limit errors again.

> release-please failed: Request failed due to following response errors: - API rate limit exceeded for installation ID ****.

This issue does not seem to have been fixed.
see https://github.com/google-github-actions/release-please-action/issues/311

This reverts commit 2ae4e5af87de8f2444689c073073ab48adf0f95d in https://github.com/sounisi5011/npm-packages/pull/577.