### PR TITLE
refactor(@sounisi5011/encrypted-archive): fix type error in `readVarint()` function

### DIFF
--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -112,7 +112,7 @@
     "@types/jest": "28.1.8",
     "@types/node": "12.20.55",
     "@types/semver": "7.3.13",
-    "@types/varint": "6.0.0",
+    "@types/varint": "6.0.1",
     "bytefield-svg": "1.7.0",
     "combinate": "1.1.11",
     "concurrently": "7.6.0",

--- a/packages/encrypted-archive/tests/unit/utils/header.ts
+++ b/packages/encrypted-archive/tests/unit/utils/header.ts
@@ -1,0 +1,102 @@
+import * as varint from 'varint';
+
+import { readVarint } from '../../../src/core/header/utils';
+import { padStartArray } from '../../helpers';
+import { DummyBufferReader } from '../../helpers/stream';
+
+describe('readVarint()', () => {
+    type ResultType = Awaited<ReturnType<typeof readVarint>>;
+    const passthroughError = (error: unknown): Error =>
+        error instanceof Error
+            ? error
+            : new Error('hoge fuga');
+
+    it.each([
+        ['00'],
+        ['0A'],
+        ['10'],
+        ['0100'],
+        ['1000'],
+        ['010000'],
+        ['100000'],
+    ])('read 0x%s', async codeStr => {
+        const codeInt = Number.parseInt(codeStr, 16);
+        const reader = new DummyBufferReader(
+            new Uint8Array(
+                varint.encode(codeInt),
+            ),
+        );
+        const byteLength = varint.encodingLength(codeInt);
+
+        const result = readVarint(reader, passthroughError);
+        await expect(result).resolves.toStrictEqual<ResultType>({
+            value: codeInt,
+            byteLength,
+            endOffset: 0 + byteLength,
+        });
+    });
+    it.each([
+        ['zero length data', Buffer.from([])],
+        ['maximum of 9 bytes data', Buffer.from(padStartArray([0x00], 9, 0xFF))],
+    ])('%s', async (_, data) => {
+        const reader = new DummyBufferReader(data);
+
+        const result = readVarint(reader, passthroughError);
+        await expect(result).rejects.toThrowWithMessage(
+            RangeError,
+            'Could not decode varint',
+        );
+    });
+    it('different offsets', async () => {
+        const reader = new DummyBufferReader(
+            new Uint8Array([
+                0b01100101,
+                0b01001000,
+                0b10011011,
+                0b11100001,
+                0b00000001,
+            ]),
+        );
+
+        await expect(readVarint(reader, passthroughError, { offset: 0 })).resolves.toStrictEqual<ResultType>({
+            value: 0b1100101 << 7 * 0,
+            byteLength: 1,
+            endOffset: 0 + 1,
+        });
+        await expect(readVarint(reader, passthroughError, { offset: 1 })).resolves.toStrictEqual<ResultType>({
+            value: 0b1001000 << 7 * 0,
+            byteLength: 1,
+            endOffset: 1 + 1,
+        });
+        await expect(readVarint(reader, passthroughError, { offset: 2 })).resolves.toStrictEqual<ResultType>({
+            value: 0b0011011 << 7 * 0 | 0b1100001 << 7 * 1 | 0b0000001 << 7 * 2,
+            byteLength: 3,
+            endOffset: 2 + 3,
+        });
+        await expect(readVarint(reader, passthroughError, { offset: 3 })).resolves.toStrictEqual<ResultType>({
+            value: 0b1100001 << 7 * 0 | 0b0000001 << 7 * 1,
+            byteLength: 2,
+            endOffset: 3 + 2,
+        });
+        await expect(readVarint(reader, passthroughError, { offset: 4 })).resolves.toStrictEqual<ResultType>({
+            value: 0b0000001 << 7 * 0,
+            byteLength: 1,
+            endOffset: 4 + 1,
+        });
+    });
+    it('offset out of range', async () => {
+        const reader = new DummyBufferReader(new Uint8Array(3));
+
+        await expect(readVarint(reader, passthroughError, { offset: 0 })).toResolve();
+        await expect(readVarint(reader, passthroughError, { offset: 1 })).toResolve();
+        await expect(readVarint(reader, passthroughError, { offset: 2 })).toResolve();
+        await expect(readVarint(reader, passthroughError, { offset: 3 })).rejects.toThrowWithMessage(
+            RangeError,
+            'Could not decode varint',
+        );
+        await expect(readVarint(reader, passthroughError, { offset: 87 })).rejects.toThrowWithMessage(
+            RangeError,
+            'Could not decode varint',
+        );
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,7 +239,7 @@ importers:
       '@types/jest': 28.1.8
       '@types/node': 12.20.55
       '@types/semver': 7.3.13
-      '@types/varint': 6.0.0
+      '@types/varint': 6.0.1
       argon2: 0.27.2
       argon2-browser: ^1.15.4
       bytefield-svg: 1.7.0
@@ -284,7 +284,7 @@ importers:
       '@types/jest': 28.1.8
       '@types/node': 12.20.55
       '@types/semver': 7.3.13
-      '@types/varint': 6.0.0
+      '@types/varint': 6.0.1
       bytefield-svg: 1.7.0
       combinate: 1.1.11
       concurrently: 7.6.0
@@ -1921,7 +1921,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 12.20.55
+      '@types/node': 16.18.11
     dev: true
 
   /@types/google-protobuf/3.15.6:
@@ -2030,10 +2030,10 @@ packages:
     resolution: {integrity: sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==}
     dev: true
 
-  /@types/varint/6.0.0:
-    resolution: {integrity: sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==}
+  /@types/varint/6.0.1:
+    resolution: {integrity: sha512-fQdOiZpDMBvaEdl12P1x7xlTPRAtd7qUUtVaWgkCy8DC//wCv19nqFFtrnR3y/ac6VFY0UUvYuQqfKzZTSE26w==}
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 16.18.11
     dev: true
 
   /@types/write-file-atomic/4.0.0:


### PR DESCRIPTION
The [`varint.decode.bytes` property](https://www.npmjs.com/package/varint/v/6.0.0#varintdecodebytes) of [the `varint@6.0.0` package](https://www.npmjs.com/package/varint/v/6.0.0) may be an `undefined` value.
