### PR TITLE
revert(monorepo-workspace-submodules-finder-action): fix(monorepo-workspace-submodules-finder-action): update the Node.js used in the environment where the action is executed to Node.js v18 (#637)

### DIFF
--- a/actions/monorepo-workspace-submodules-finder/action.yaml
+++ b/actions/monorepo-workspace-submodules-finder/action.yaml
@@ -23,5 +23,5 @@ outputs:
   submodule-exists:
     description: If `result` contains one or more submodules, it is `true`.
 runs:
-  using: node18
+  using: node16
   main: dist/index.js

--- a/actions/monorepo-workspace-submodules-finder/package.json
+++ b/actions/monorepo-workspace-submodules-finder/package.json
@@ -38,7 +38,7 @@
     "@swc/core": "1.3.25",
     "@swc/jest": "0.2.24",
     "@types/jest": "29.2.5",
-    "@types/node": "18.11.18",
+    "@types/node": "16.18.11",
     "@types/validate-npm-package-name": "4.0.0",
     "@vercel/ncc": "0.36.0",
     "cross-env": "7.0.3",
@@ -50,6 +50,6 @@
     "ultra-runner": "3.10.5"
   },
   "engines": {
-    "node": "18"
+    "node": "16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1921,7 +1921,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
     dev: true
 
   /@types/google-protobuf/3.15.6:
@@ -2033,7 +2033,7 @@ packages:
   /@types/varint/6.0.1:
     resolution: {integrity: sha512-fQdOiZpDMBvaEdl12P1x7xlTPRAtd7qUUtVaWgkCy8DC//wCv19nqFFtrnR3y/ac6VFY0UUvYuQqfKzZTSE26w==}
     dependencies:
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
     dev: true
 
   /@types/write-file-atomic/4.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
       '@swc/core': 1.3.25
       '@swc/jest': 0.2.24
       '@types/jest': 29.2.5
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       '@types/validate-npm-package-name': 4.0.0
       '@vercel/ncc': 0.36.0
       cross-env: 7.0.3
@@ -102,11 +102,11 @@ importers:
       '@swc/core': 1.3.25
       '@swc/jest': 0.2.24_@swc+core@1.3.25
       '@types/jest': 29.2.5
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       '@types/validate-npm-package-name': 4.0.0
       '@vercel/ncc': 0.36.0
       cross-env: 7.0.3
-      jest: 29.3.1_@types+node@18.11.18
+      jest: 29.3.1_@types+node@16.18.11
       jest-mock-process: 2.0.0_jest@29.3.1
       nock: 13.2.9
       spawk: 1.8.0
@@ -998,7 +998,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       jest-message-util: 29.3.1
       jest-util: 29.3.1
@@ -1062,14 +1062,14 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.2.0
-      jest-config: 29.3.1_@types+node@18.11.18
+      jest-config: 29.3.1_@types+node@16.18.11
       jest-haste-map: 29.3.1
       jest-message-util: 29.3.1
       jest-regex-util: 29.2.0
@@ -1113,7 +1113,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       jest-mock: 29.3.1
     dev: true
 
@@ -1169,7 +1169,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       jest-message-util: 29.3.1
       jest-mock: 29.3.1
       jest-util: 29.3.1
@@ -1251,7 +1251,7 @@ packages:
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -1420,7 +1420,7 @@ packages:
       '@jest/schemas': 29.0.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       '@types/yargs': 17.0.19
       chalk: 4.1.2
     dev: true
@@ -1990,10 +1990,6 @@ packages:
 
   /@types/node/16.18.11:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
-    dev: true
-
-  /@types/node/18.11.18:
-    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -5135,7 +5131,7 @@ packages:
       '@jest/expect': 29.3.1
       '@jest/test-result': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -5266,7 +5262,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli/29.3.1_@types+node@18.11.18:
+  /jest-cli/29.3.1_@types+node@16.18.11:
     resolution: {integrity: sha512-TO/ewvwyvPOiBBuWZ0gm04z3WWP8TIK8acgPzE4IxgsLKQgb377NYGrQLc3Wl/7ndWzIH2CDNNsUjGxwLL43VQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -5283,7 +5279,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.3.1_@types+node@18.11.18
+      jest-config: 29.3.1_@types+node@16.18.11
       jest-util: 29.3.1
       jest-validate: 29.3.1
       prompts: 2.4.2
@@ -5449,7 +5445,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config/29.3.1_@types+node@18.11.18:
+  /jest-config/29.3.1_@types+node@16.18.11:
     resolution: {integrity: sha512-y0tFHdj2WnTEhxmGUK1T7fgLen7YK4RtfvpLFBXfQkh2eMJAQq24Vx9472lvn5wg0MAO6B+iPfJfzdR9hJYalg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -5464,7 +5460,7 @@ packages:
       '@babel/core': 7.20.12
       '@jest/test-sequencer': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       babel-jest: 29.3.1_@babel+core@7.20.12
       chalk: 4.1.2
       ci-info: 3.7.1
@@ -5562,7 +5558,7 @@ packages:
       '@jest/environment': 29.3.1
       '@jest/fake-timers': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       jest-mock: 29.3.1
       jest-util: 29.3.1
     dev: true
@@ -5612,7 +5608,7 @@ packages:
     dependencies:
       '@jest/types': 29.3.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -5696,7 +5692,7 @@ packages:
     peerDependencies:
       jest: '>=23.4'
     dependencies:
-      jest: 29.3.1_@types+node@18.11.18
+      jest: 29.3.1_@types+node@16.18.11
     dev: true
 
   /jest-mock/28.1.3:
@@ -5712,7 +5708,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       jest-util: 29.3.1
     dev: true
 
@@ -5838,7 +5834,7 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.10
@@ -5899,7 +5895,7 @@ packages:
       '@jest/test-result': 29.3.1
       '@jest/transform': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -6003,7 +5999,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10
@@ -6054,7 +6050,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.3.1
       '@jest/types': 29.3.1
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6075,7 +6071,7 @@ packages:
     resolution: {integrity: sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.11.18
+      '@types/node': 16.18.11
       jest-util: 29.3.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -6161,7 +6157,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest/29.3.1_@types+node@18.11.18:
+  /jest/29.3.1_@types+node@16.18.11:
     resolution: {integrity: sha512-6iWfL5DTT0Np6UYs/y5Niu7WIfNv/wRTtN5RSXt2DIEft3dx3zPuw/3WJQBCJfmEzvDiEKwoqMbGD9n49+qLSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -6174,7 +6170,7 @@ packages:
       '@jest/core': 29.3.1
       '@jest/types': 29.3.1
       import-local: 3.1.0
-      jest-cli: 29.3.1_@types+node@18.11.18
+      jest-cli: 29.3.1_@types+node@16.18.11
     transitivePeerDependencies:
       - '@types/node'
       - supports-color


### PR DESCRIPTION
GitHub Actions did not yet support "using: node18"

This reverts commit e9b36f5b4ab671e6c69bd71085d0c49ae871e32d.