### PR TITLE
chore(renovate): disable automatic updates for some packages that don't work with supported Node.js

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -6,12 +6,7 @@
     "helpers:disableTypesNodeMajor",
   ],
   ignorePresets: ["group:monorepos"],
-  ignoreDeps: [
-    "argon2",
-    // `jest-extended@>=3.1.0` does not work with Node.js v12
-    // see https://github.com/sounisi5011/npm-packages/pull/626/commits/de18896e0f1881c8a59956c023189584fba73400
-    "jest-extended",
-  ],
+  ignoreDeps: ["argon2"],
   packageRules: [
     {
       matchPaths: ["actions/**"],
@@ -49,9 +44,65 @@
       groupName: "test packages",
       groupSlug: "tester-packages",
     },
+    // `@sounisi5011/run-if-supported@>=2.0.0` doesn't work with old Node.js.
+    // Because it uses pure ESM, `node:` imports, and the new ECMAScript syntax (`obj?.prop`, `leftExpr ?? rightExpr`, etc.) supported since Node.js 14.
+    // see https://github.com/sounisi5011/npm-packages/pull/488/commits/54a975fccf7d41d49201951f4eb8c7454238ddcc and https://github.com/sounisi5011/npm-packages/pull/496
+    // We should only update if the Node.js support range for packages that use this is: `>=14.13.1`
     {
       matchPackageNames: ["@sounisi5011/run-if-supported"],
-      extends: [":disableMajorUpdates"],
+      matchCurrentVersion: "<2.0.0",
+      enabled: false,
+    },
+    // `cpy-cli@>=4.0.0` doesn't work with old Node.js.
+    // Because it uses pure ESM and `node:` imports.
+    // see https://github.com/sounisi5011/npm-packages/pull/500/commits/8cf7dd1c839331663097cca92ab70d344464bd3e
+    // We should only update if the Node.js support range for packages that use this is: `^12.20.0 || >=14.13.1`
+    {
+      matchPackageNames: ["cpy-cli"],
+      matchCurrentVersion: "<4.0.0",
+      enabled: false,
+    },
+    // `escape-string-regexp@>=5.0.0` doesn't work with old Node.js.
+    // Because it uses pure ESM.
+    // We should only update if the Node.js support range for packages that use this is: `^12.20.0 || >=14.13.0`
+    {
+      matchPackageNames: ["escape-string-regexp"],
+      matchCurrentVersion: "<5.0.0",
+      enabled: false,
+    },
+    // `execa@>=6.0.0` doesn't work with old Node.js.
+    // Because it uses pure ESM and `node:` imports.
+    // We should only update if the Node.js support range for packages that use this is: `^12.20.0 || >=14.13.1`
+    {
+      matchPackageNames: ["execa"],
+      matchCurrentVersion: "<6.0.0",
+      enabled: false,
+    },
+    // `jest@>=29.0.0` and `jest-diff@>=29.0.0` does not work with Node.js v12.
+    // Because it uses the new ECMAScript syntax (`obj?.prop`, `leftExpr ?? rightExpr`, etc.) supported since Node.js 14.
+    // We should only update if the Node.js support range for packages that use this is: `>=14.0.0`
+    {
+      matchPackageNames: ["jest", "@types/jest", "jest-diff"],
+      matchCurrentVersion: "<29.0.0",
+      enabled: false,
+    },
+    // `jest-extended@>=3.1.0` does not work with Node.js v12.
+    // Because it uses the new ECMAScript syntax (`obj?.prop`, `leftExpr ?? rightExpr`, etc.) supported since Node.js 14.
+    // see https://github.com/sounisi5011/npm-packages/pull/626/commits/de18896e0f1881c8a59956c023189584fba73400
+    // We should only update if the Node.js support range for packages that use this is: `>=14.0.0`
+    {
+      matchPackageNames: ["jest-extended"],
+      matchCurrentVersion: "<3.1.0",
+      enabled: false,
+    },
+    // `rollup@>=3.0.0` doesn't work with old Node.js.
+    // Because it uses `node:` import by the `require()` function.
+    // see https://github.com/sounisi5011/npm-packages/pull/613#issuecomment-1374276503
+    // We should only update if the Node.js support range for packages that use this is: `>=14.18.0`
+    {
+      matchPackageNames: ["rollup"],
+      matchCurrentVersion: "<3.0.0",
+      enabled: false,
     },
   ],
 }


### PR DESCRIPTION
Disabled automatic updates for some packages that do not work with supported Node.js.

+ `@sounisi5011/run-if-supported@>=2.0.0`

    Because it uses pure ESM, `node:` imports, and the new ECMAScript syntax (`obj?.prop`, `leftExpr ?? rightExpr`, etc.) supported since Node.js 14.
    see https://github.com/sounisi5011/npm-packages/pull/488/commits/54a975fccf7d41d49201951f4eb8c7454238ddcc and https://github.com/sounisi5011/npm-packages/pull/496
    We should only update if the Node.js support range for packages that use this is: `>=14.13.1`

+ `cpy-cli@>=4.0.0` and `execa@>=6.0.0`

    Because it uses pure ESM and `node:` imports.
    see https://github.com/sounisi5011/npm-packages/pull/500/commits/8cf7dd1c839331663097cca92ab70d344464bd3e
    We should only update if the Node.js support range for packages that use this is: `^12.20.0 || >=14.13.1`

+ `escape-string-regexp@>=5.0.0`

    Because it uses pure ESM.
    We should only update if the Node.js support range for packages that use this is: `^12.20.0 || >=14.13.0`

+ `jest@>=29.0.0`, `jest-diff@>=29.0.0`, and `jest-extended@>=3.1.0`

    Because it uses the new ECMAScript syntax (`obj?.prop`, `leftExpr ?? rightExpr`, etc.) supported since Node.js 14.
    see https://github.com/sounisi5011/npm-packages/pull/626/commits/de18896e0f1881c8a59956c023189584fba73400
    We should only update if the Node.js support range for packages that use this is: `>=14.0.0`

+ `rollup@>=3.0.0`

    Because it uses `node:` import by the `require()` function.
    see https://github.com/sounisi5011/npm-packages/pull/613#issuecomment-1374276503
    We should only update if the Node.js support range for packages that use this is: `>=14.18.0`