### PR TITLE
fix(package.json): add `"types"` import condition to the `exports` field in `package.json`

### DIFF
--- a/packages/check-pid-file/package.json
+++ b/packages/check-pid-file/package.json
@@ -25,7 +25,10 @@
   "author": "sounisi5011",
   "type": "commonjs",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/cli-utils/top-level-await-cli/package.json
+++ b/packages/cli-utils/top-level-await-cli/package.json
@@ -15,7 +15,10 @@
   "author": "sounisi5011",
   "type": "commonjs",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/encrypted-archive/package.json
+++ b/packages/encrypted-archive/package.json
@@ -50,7 +50,10 @@
   "author": "sounisi5011",
   "type": "commonjs",
   "exports": {
-    ".": "./dist/index.node.js",
+    ".": {
+      "types": "./dist/index.node.d.ts",
+      "default": "./dist/index.node.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.node.js",

--- a/packages/jest-matchers/binary-data/package.json
+++ b/packages/jest-matchers/binary-data/package.json
@@ -35,7 +35,10 @@
   "author": "sounisi5011",
   "type": "commonjs",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/stream-transform-from/package.json
+++ b/packages/stream-transform-from/package.json
@@ -52,7 +52,10 @@
   "author": "sounisi5011",
   "type": "commonjs",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/ts-type-utils/has-own-property/package.json
+++ b/packages/ts-type-utils/has-own-property/package.json
@@ -23,6 +23,12 @@
   },
   "license": "MIT",
   "author": "sounisi5011",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "types": "./index.d.ts",
   "files": [
     "/CHANGELOG.md",

--- a/packages/ts-type-utils/is-readonly-array/package.json
+++ b/packages/ts-type-utils/is-readonly-array/package.json
@@ -25,6 +25,12 @@
   },
   "license": "MIT",
   "author": "sounisi5011",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "types": "./index.d.ts",
   "files": [
     "/CHANGELOG.md",


### PR DESCRIPTION
If there is an `exports` field in `package.json`, TypeScript will now look for a type declaration file using the `"types"` import condition instead of the `types` field.
see https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

Even if there is no `"types"` import condition, TypeScript will not use the `types` field.
So TypeScript **will not find a type declaration file**.

However, this problem *does not happen with published packages*.
so far, the published packages have the same name for a type declaration files and a `.js` files.
In this case, TypeScript will automatically find a type declaration file.

But if in future package updates we rename `.js` files and type declaration files, this problem will start to happen.
I don't know if we will remember this problem at that time.
We may release a package containing this problem without knowing it.

Therefore, add a `"types"` import condition to the `package.json` of all packages that require a type declaration file.