### PR TITLE
docs(@sounisi5011/encrypted-archive): remove unnecessary `require()` statements from the example code in the `README.md`

### DIFF
--- a/packages/encrypted-archive/README.md
+++ b/packages/encrypted-archive/README.md
@@ -187,7 +187,6 @@ stream.pipeline(
 
 ```js
 const fs = require('fs');
-const stream = require('stream');
 const { encryptIterator, decryptIterator } = require('@sounisi5011/encrypted-archive');
 
 const password = '1234';


### PR DESCRIPTION
The example code for the Async Iteration API contained unnecessary code: the code to import the `stream` module.