### PR TITLE
ci(github actions): reuse `node_modules` directory and build results for each job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,11 +92,11 @@ jobs:
         shell: bash
         run: |
           echo '::group::' Archive installed dependencies
-          git ls-files --modified --others --directory -z -- ':(glob)**/node_modules/' | xargs -0 tar -c --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+          git ls-files --modified --others --directory -z -- ':(glob,exclude)*.tar.gz' ':(glob)**/node_modules/' | xargs -0 tar -c --file ./node_modules--${{ runner.os }}.tar.gz --gzip
           echo '::endgroup::'
 
           echo '::group::' Archive build results
-          git ls-files --modified --others --directory -z -- ':(glob,exclude)**/node_modules/' | xargs -0 tar -c --file ./build_results.tar.gz --gzip --verbose
+          git ls-files --modified --others --directory -z -- ':(glob,exclude)*.tar.gz' ':(glob,exclude)**/node_modules/' | xargs -0 tar -c --file ./build_results.tar.gz --gzip --verbose
           echo '::endgroup::'
         # Note: Convert the node_modules directory and the build result into a single archive file. This is for the following reasons:
         #       + Maintaining file permissions and case sensitive files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
           echo '::endgroup::'
 
           echo '::group::' Archive build results
-          git ls-files --modified --others --exclude='node_modules/' -z | xargs -0 tar -cvjf ./build_results.tar.bz2
+          git ls-files --modified --others --directory -z -- ':(glob,exclude)**/node_modules/' | xargs -0 tar -c --file ./build_results.tar.gz --gzip --verbose
           echo '::endgroup::'
         # Note: Convert the node_modules directory and the build result into a single archive file. This is for the following reasons:
         #       + Maintaining file permissions and case sensitive files
@@ -113,7 +113,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: build-results@${{ github.sha }}
-          path: build_results.tar.bz2
+          path: build_results.tar.gz
           retention-days:
             1
             # The resulting artifact of the build is intended to be used in the next job.
@@ -138,7 +138,7 @@ jobs:
       - name: Restore installed dependencies and build results
         run: |
           tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -xvjf ./build_results.tar.bz2
+          tar -x --file ./build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -175,7 +175,7 @@ jobs:
       - name: Restore installed dependencies and build results
         run: |
           tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -xvjf ./build_results.tar.bz2
+          tar -x --file ./build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -292,7 +292,7 @@ jobs:
       - name: Restore installed dependencies and build results
         run: |
           tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -xvjf ./build_results.tar.bz2
+          tar -x --file ./build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -413,7 +413,7 @@ jobs:
             tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
             echo 'node_modules=1' >> $GITHUB_OUTPUT
           fi
-          tar -xvjf ./build_results.tar.bz2
+          tar -x --file ./build_results.tar.gz --gzip
       - name: Git Setting
         run: |
           git config --global user.name  CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,15 +145,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Cache actionlint
         uses: actions/cache@v3
         with:
@@ -165,9 +156,6 @@ jobs:
           key: actionlint-${{ runner.os }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
-      - run: pnpm run build-only-packages
       - run: pnpm run lint
   format:
     needs: pre-build
@@ -196,19 +184,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
       - name: Setup dprint
         # The dprint command may fail to deserialize the wasm module.
         # This only happens on CI, and in some cases no error occurs.
@@ -288,7 +265,6 @@ jobs:
             }
           }
           echo '::endgroup::'
-      - run: pnpm run build-only-packages
       - # In rare cases, the "fmt" script may fail.
         # In that case, it will try formatting again after 5 seconds.
         shell: bash
@@ -327,19 +303,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
       - name: Install flatbuffers
         # https://snapcraft.io/flatbuffers
         run: |
@@ -454,6 +419,7 @@ jobs:
         run: |
           if [ -e ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz ]; then
             tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
+            echo 'node_modules=1' >> "${GITHUB_OUTPUT}"
           fi
           tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Git Setting
@@ -473,11 +439,12 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
+        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
-      - run: pnpm run build-only-packages
+        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - run: pnpm run test-only
   complete:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,14 +131,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: node_modules@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Restore installed dependencies and build results
         run: |
-          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -x --file ./build_results.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -168,14 +170,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: node_modules@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Restore installed dependencies and build results
         run: |
-          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -x --file ./build_results.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -285,14 +289,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: node_modules@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Restore installed dependencies and build results
         run: |
-          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-          tar -x --file ./build_results.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -401,19 +407,21 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: node_modules@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
+          path: ~/pre-build-artifact
       - name: Restore installed dependencies and build results
         id: restore-deps-and-build
         shell: bash
         run: |
-          if [ -e ./node_modules--${{ runner.os }}.tar.gz ]; then
-            tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+          if [ -e ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz ]; then
+            tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
             echo 'node_modules=1' >> "${GITHUB_OUTPUT}"
           fi
-          tar -x --file ./build_results.tar.gz --gzip
+          tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Git Setting
         run: |
           git config --global user.name  CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,12 +51,12 @@ jobs:
             echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"
           fi
   pre-build:
-    # It is not necessary to build every time within each job.
-    # Also, the build result is not dependent on either OS type or Node.js version.
+    # There is no need to install dependencies and build every time within each job.
+    # Also, the contents of the node_modules directory and the build results are not dependent on the Node.js version.
     # Therefore, "build-only-packages" are performed in advance and the build results are shared with subsequent jobs.
     # This provides the following advantages:
     #
-    # + Reduces build time
+    # + Reduced execution time for each job
     #
     # + Build process does not need to support older Node.js
     #   Note: Some unit tests build while the test is running.
@@ -87,20 +87,28 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
       - name: Build packages
+        run: pnpm run build-only-packages
+      - name: Create archive files
         shell: bash
         run: |
-          echo '::group::' '$' pnpm run build-only-packages
-          pnpm run build-only-packages
+          echo '::group::' Archive installed dependencies
+          git ls-files --modified --others --directory -z -- ':(glob)**/node_modules/' | xargs -0 tar -c --file ./node_modules--${{ runner.os }}.tar.gz --gzip
           echo '::endgroup::'
 
           echo '::group::' Archive build results
           git ls-files --modified --others --exclude='node_modules/' -z | xargs -0 tar -cvjf ./build_results.tar.bz2
           echo '::endgroup::'
-        # Note: Convert the build result into a single archive file. This is for the following reasons:
+        # Note: Convert the node_modules directory and the build result into a single archive file. This is for the following reasons:
         #       + Maintaining file permissions and case sensitive files
         #         see https://github.com/actions/upload-artifact/blob/v3.1.2/README.md#maintaining-file-permissions-and-case-sensitive-files
         #       + Reduce the number of API calls
         #         see https://github.com/actions/upload-artifact/blob/v3.1.2/README.md#too-many-uploads-resulting-in-429-responses
+      - name: Upload installed dependencies
+        uses: actions/upload-artifact@v3
+        with:
+          name: node_modules@${{ github.sha }}
+          path: node_modules--${{ runner.os }}.tar.gz
+          retention-days: 1
       - name: Upload build results
         uses: actions/upload-artifact@v3
         with:
@@ -119,25 +127,22 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download installed dependencies
+        uses: actions/download-artifact@v3
+        with:
+          name: node_modules@${{ github.sha }}
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
-      - name: Restore build results
-        run: tar -xvjf ./build_results.tar.bz2
+      - name: Restore installed dependencies and build results
+        run: |
+          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -xvjf ./build_results.tar.bz2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Cache actionlint
         uses: actions/cache@v3
         with:
@@ -149,8 +154,6 @@ jobs:
           key: actionlint-${{ runner.os }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
       - run: pnpm run lint
   format:
     needs: pre-build
@@ -161,29 +164,24 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download installed dependencies
+        uses: actions/download-artifact@v3
+        with:
+          name: node_modules@${{ github.sha }}
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
-      - name: Restore build results
-        run: tar -xvjf ./build_results.tar.bz2
+      - name: Restore installed dependencies and build results
+        run: |
+          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -xvjf ./build_results.tar.bz2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
       - name: Setup dprint
         # The dprint command may fail to deserialize the wasm module.
         # This only happens on CI, and in some cases no error occurs.
@@ -275,7 +273,7 @@ jobs:
         if: ${{ always() }}
         run: git diff --name-only --exit-code
   build:
-    needs: if-run-ci
+    needs: pre-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -283,23 +281,24 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download installed dependencies
+        uses: actions/download-artifact@v3
+        with:
+          name: node_modules@${{ github.sha }}
+      - name: Download build results
+        uses: actions/download-artifact@v3
+        with:
+          name: build-results@${{ github.sha }}
+      - name: Restore installed dependencies and build results
+        run: |
+          tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+          tar -xvjf ./build_results.tar.bz2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
-      - name: Install Dependencies
-        run: pnpm install
       - name: Install flatbuffers
         # https://snapcraft.io/flatbuffers
         run: |
@@ -398,12 +397,23 @@ jobs:
           - 18.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download installed dependencies
+        uses: actions/download-artifact@v3
+        with:
+          name: node_modules@${{ github.sha }}
       - name: Download build results
         uses: actions/download-artifact@v3
         with:
           name: build-results@${{ github.sha }}
-      - name: Restore build results
-        run: tar -xvjf ./build_results.tar.bz2
+      - name: Restore installed dependencies and build results
+        id: restore-deps-and-build
+        shell: bash
+        run: |
+          if [ -e ./node_modules--${{ runner.os }}.tar.gz ]; then
+            tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
+            echo 'node_modules=1' >> $GITHUB_OUTPUT
+          fi
+          tar -xvjf ./build_results.tar.bz2
       - name: Git Setting
         run: |
           git config --global user.name  CI
@@ -421,10 +431,12 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
+        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
+        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - run: pnpm run test-only
   complete:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,17 @@ jobs:
           elif [ "${core_remaining}" -lt 10 ]; then
             echo "::warning::The rate limit is approaching: core.remaining=${core_remaining}"
           fi
-  lint:
+  pre-build:
+    # It is not necessary to build every time within each job.
+    # Also, the build result is not dependent on either OS type or Node.js version.
+    # Therefore, "build-only-packages" are performed in advance and the build results are shared with subsequent jobs.
+    # This provides the following advantages:
+    #
+    # + Reduces build time
+    #
+    # + Build process does not need to support older Node.js
+    #   Note: Some unit tests build while the test is running.
+    #         In such cases, the build process must support older Node.js.
     needs: if-run-ci
     runs-on: ubuntu-latest
     strategy:
@@ -59,6 +69,62 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
+      - name: Setup pnpm
+        uses: ./actions/setup-pnpm
+      - name: Install Dependencies
+        run: pnpm install
+      - name: Build packages
+        shell: bash
+        run: |
+          echo '::group::' '$' pnpm run build-only-packages
+          pnpm run build-only-packages
+          echo '::endgroup::'
+
+          echo '::group::' Archive build results
+          git ls-files --modified --others --exclude='node_modules/' -z | xargs -0 tar -cvjf ./build_results.tar.bz2
+          echo '::endgroup::'
+        # Note: Convert the build result into a single archive file. This is for the following reasons:
+        #       + Maintaining file permissions and case sensitive files
+        #         see https://github.com/actions/upload-artifact/blob/v3.1.2/README.md#maintaining-file-permissions-and-case-sensitive-files
+        #       + Reduce the number of API calls
+        #         see https://github.com/actions/upload-artifact/blob/v3.1.2/README.md#too-many-uploads-resulting-in-429-responses
+      - name: Upload build results
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-results@${{ github.sha }}
+          path: build_results.tar.bz2
+          retention-days:
+            1
+            # The resulting artifact of the build is intended to be used in the next job.
+            # There is no need to store them for long periods of time.
+  lint:
+    needs: pre-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 16.x
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download build results
+        uses: actions/download-artifact@v3
+        with:
+          name: build-results@${{ github.sha }}
+      - name: Restore build results
+        run: tar -xvjf ./build_results.tar.bz2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -85,10 +151,9 @@ jobs:
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
-      - run: pnpm run build-only-packages
       - run: pnpm run lint
   format:
-    needs: if-run-ci
+    needs: pre-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,6 +161,12 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download build results
+        uses: actions/download-artifact@v3
+        with:
+          name: build-results@${{ github.sha }}
+      - name: Restore build results
+        run: tar -xvjf ./build_results.tar.bz2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -192,7 +263,6 @@ jobs:
             }
           }
           echo '::endgroup::'
-      - run: pnpm run build-only-packages
       - # In rare cases, the "fmt" script may fail.
         # In that case, it will try formatting again after 5 seconds.
         shell: bash
@@ -300,7 +370,7 @@ jobs:
             echo '::notice::No uncommitted changes by build'
           fi
   unit-test:
-    needs: if-run-ci
+    needs: pre-build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -328,6 +398,12 @@ jobs:
           - 18.x
     steps:
       - uses: actions/checkout@v3
+      - name: Download build results
+        uses: actions/download-artifact@v3
+        with:
+          name: build-results@${{ github.sha }}
+      - name: Restore build results
+        run: tar -xvjf ./build_results.tar.bz2
       - name: Git Setting
         run: |
           git config --global user.name  CI
@@ -349,7 +425,6 @@ jobs:
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
-      - run: pnpm run build-only-packages
       - run: pnpm run test-only
   complete:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,6 +145,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Cache actionlint
         uses: actions/cache@v3
         with:
@@ -156,6 +165,9 @@ jobs:
           key: actionlint-${{ runner.os }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
+      - name: Install Dependencies
+        run: pnpm install
+      - run: pnpm run build-only-packages
       - run: pnpm run lint
   format:
     needs: pre-build
@@ -184,8 +196,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
+      - name: Install Dependencies
+        run: pnpm install
       - name: Setup dprint
         # The dprint command may fail to deserialize the wasm module.
         # This only happens on CI, and in some cases no error occurs.
@@ -265,6 +288,7 @@ jobs:
             }
           }
           echo '::endgroup::'
+      - run: pnpm run build-only-packages
       - # In rare cases, the "fmt" script may fail.
         # In that case, it will try formatting again after 5 seconds.
         shell: bash
@@ -303,8 +327,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Cache .pnpm-store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ matrix.node-version }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
+      - name: Install Dependencies
+        run: pnpm install
       - name: Install flatbuffers
         # https://snapcraft.io/flatbuffers
         run: |
@@ -419,7 +454,6 @@ jobs:
         run: |
           if [ -e ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz ]; then
             tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.gz --gzip
-            echo 'node_modules=1' >> "${GITHUB_OUTPUT}"
           fi
           tar -x --file ~/pre-build-artifact/build_results.tar.gz --gzip
       - name: Git Setting
@@ -439,12 +473,11 @@ jobs:
             ${{ runner.os }}-node-${{ matrix.node-version }}-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
-        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - name: Setup pnpm
         uses: ./actions/setup-pnpm
       - name: Install Dependencies
         run: pnpm install
-        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
+      - run: pnpm run build-only-packages
       - run: pnpm run test-only
   complete:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -411,7 +411,7 @@ jobs:
         run: |
           if [ -e ./node_modules--${{ runner.os }}.tar.gz ]; then
             tar -x --file ./node_modules--${{ runner.os }}.tar.gz --gzip
-            echo 'node_modules=1' >> $GITHUB_OUTPUT
+            echo 'node_modules=1' >> "${GITHUB_OUTPUT}"
           fi
           tar -x --file ./build_results.tar.gz --gzip
       - name: Git Setting


### PR DESCRIPTION
It is not necessary to build every time within each job. Also, the build result is not dependent on either OS type or Node.js version.
Therefore, "build-only-packages" are performed in advance and the build results are shared with subsequent jobs. This provides the following advantages:

+ Reduces build time
+ Build process does not need to support older Node.js
  Note: Some unit tests build while the test is running. In such cases, the build process must support older Node.js.