### PR TITLE
ci(update-license-year): update all `LICENSE` files

### DIFF
--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -14,10 +14,11 @@ jobs:
         run: |
           delimiter="ghadelimiter_$(openssl rand -hex 32)"
           readonly delimiter
-
-          echo "files<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          git ls-files ':(glob)**/LICENSE' >> "${GITHUB_OUTPUT}"
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "files<<${delimiter}"
+            git ls-files ':(glob)**/LICENSE'
+            echo "${delimiter}"
+          } >> "${GITHUB_OUTPUT}"
         # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         # see https://gotohayato.com/content/558/
       - uses: FantasticFiasco/action-update-license-year@v2

--- a/.github/workflows/update-license-year.yaml
+++ b/.github/workflows/update-license-year.yaml
@@ -8,11 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Find all LICENSE files
+        id: find-all-license-files
+        shell: bash
+        run: |
+          delimiter="ghadelimiter_$(openssl rand -hex 32)"
+          readonly delimiter
+
+          echo "files<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          git ls-files ':(glob)**/LICENSE' >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+        # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+        # see https://gotohayato.com/content/558/
       - uses: FantasticFiasco/action-update-license-year@v2
         with:
           # Use personal access token instead of GITHUB_TOKEN to execute CI for pull requests.
           # see https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           token: ${{ secrets.TRIGGER_TEST_GITHUB_TOKEN }}
+          path: |
+            ${{ steps.find-all-license-files.outputs.files }}
           commitTitle: |
             docs(license): update copyright year(s)
           prTitle: |


### PR DESCRIPTION
The `LICENSE` files do not necessarily exist only in the project root.
`LICENSE` files in subdirectories must also be automatically updated.

Some packages may use different license files.
For example, since it is currently 2023, a new package created this year must adopt a license starting in 2023.
In such cases, the `LICENSE` files are placed in the directory of each package.