### PR TITLE
chore(editor): override syntax highlighting settings in GitHub and VSCode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
 tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
+/.vscode/**/*.json linguist-language=JSON-with-Comments
 # The dprint configuration file is parsed as jsonc.
 # see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
 # see https://github.com/dprint/jsonc-parser

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 .ultraignore linguist-language=Ignore-List
 tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
-/.vscode/**/*.json linguist-language=JSON-with-Comments
 
 # The dprint configuration file is parsed as jsonc.
 # see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,12 @@
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
 tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
+# The dprint configuration file is parsed as jsonc.
+# see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
+# see https://github.com/dprint/jsonc-parser
+# Not JSON5.
+# dprint implementation can use features not available in jsonc (e.g., trailing commas),
+# but not some JSON5 features (e.g., multi-line strings and `Infinity` values).
+dprint.json linguist-language=JSON-with-Comments
+.dprint.json linguist-language=JSON-with-Comments
+.dprint[.-]*.json linguist-language=JSON-with-Comments

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,14 @@
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
 
 .ultraignore linguist-language=Ignore-List
-tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
+
+# GitHub detects only `tsconfig.json` files as jsonc by default.
+# see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L3123
+# However, VSCode also detects `tsconfig.*.json` and `tsconfig-*.json` as jsonc.
+# see https://github.com/microsoft/vscode/blob/1.75.1/extensions/typescript-language-features/package.json#L79-L106
+# We will also use the latter filename, so we will tell GitHub that these are jsonc.
+tsconfig[.-]*.json linguist-language=JSON-with-Comments
 
 # The dprint configuration file is parsed as jsonc.
 # see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,19 +4,19 @@
 .ultraignore linguist-language=Ignore-List
 turbo.json linguist-language=JSON-with-Comments
 
-# GitHub detects only `tsconfig.json` files as jsonc by default.
+# GitHub detects only `tsconfig.json` files as JSONC by default.
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L3123
-# However, VSCode also detects `tsconfig.*.json` and `tsconfig-*.json` as jsonc.
+# However, VSCode also detects `tsconfig.*.json` and `tsconfig-*.json` as JSONC.
 # see https://github.com/microsoft/vscode/blob/1.75.1/extensions/typescript-language-features/package.json#L79-L106
-# We will also use the latter filename, so we will tell GitHub that these are jsonc.
+# We will also use the latter filename, so we will tell GitHub that these are JSONC.
 tsconfig[.-]*.json linguist-language=JSON-with-Comments
 
-# The dprint configuration file is parsed as jsonc.
+# The dprint configuration file is parsed as JSONC.
 # see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
 # see https://github.com/dprint/jsonc-parser
-# Not JSON5.
-# dprint implementation can use features not available in jsonc (e.g., trailing commas),
-# but not some JSON5 features (e.g., multi-line strings and `Infinity` values).
+# **Not JSON5.**
+# The dprint implementation can use features not available in JSONC (e.g., trailing commas).
+# But some features of JSON5 (e.g., multi-line strings, `Infinity` values) cannot be used.
 dprint.json linguist-language=JSON-with-Comments
 .dprint.json linguist-language=JSON-with-Comments
 .dprint[.-]*.json linguist-language=JSON-with-Comments
@@ -25,6 +25,6 @@ dprint.json linguist-language=JSON-with-Comments
 #       it is better to use other extensions that are default supported by GitHub.
 #       E.g., ".textproto", ".pbt", ".pbtxt"
 #       see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L5276-L5287
-#       ".pbtxt" is recommended. because this is the canonical file extension.
+#       ".textproto" is recommended. because this is the canonical file extension.
 #       see https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files
 *.prototxt linguist-language=Protocol-Buffer-Text-Format

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,11 @@
 # Change syntax highlighting on GitHub
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
+
 .ultraignore linguist-language=Ignore-List
 tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
 /.vscode/**/*.json linguist-language=JSON-with-Comments
+
 # The dprint configuration file is parsed as jsonc.
 # see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
 # see https://github.com/dprint/jsonc-parser
@@ -13,3 +15,11 @@ turbo.json linguist-language=JSON-with-Comments
 dprint.json linguist-language=JSON-with-Comments
 .dprint.json linguist-language=JSON-with-Comments
 .dprint[.-]*.json linguist-language=JSON-with-Comments
+
+# Note: Rather than using the file extension ".prototxt",
+#       it is better to use other extensions that are default supported by GitHub.
+#       E.g., ".textproto", ".pbt", ".pbtxt"
+#       see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L5276-L5287
+#       ".pbtxt" is recommended. because this is the canonical file extension.
+#       see https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files
+*.prototxt linguist-language=Protocol-Buffer-Text-Format

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Change syntax highlighting on GitHub
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
+.ultraignore linguist-language=Ignore-List
 tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments
 /.vscode/**/*.json linguist-language=JSON-with-Comments

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Change syntax highlighting on GitHub
 # see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
+tsconfig.*.json linguist-language=JSON-with-Comments
 turbo.json linguist-language=JSON-with-Comments

--- a/.vscode/.gitattributes
+++ b/.vscode/.gitattributes
@@ -1,0 +1,3 @@
+# Change syntax highlighting on GitHub
+# see https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/docs/overrides.md
+*.json linguist-language=JSON-with-Comments

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
   "files.associations": {
+    ".prettierignore": "ignore",
+    ".ultraignore": "ignore",
     "turbo.json": "jsonc",
     /**
      * The dprint configuration file is parsed as jsonc.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,12 +4,12 @@
     ".{prettier,ultra}ignore": "ignore",
     "turbo.json": "jsonc",
     /**
-     * The dprint configuration file is parsed as jsonc.
+     * The dprint configuration file is parsed as JSONC.
      * see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
      * see https://github.com/dprint/jsonc-parser
-     * Not JSON5.
-     * dprint implementation can use features not available in jsonc (e.g., trailing commas),
-     * but not some JSON5 features (e.g., multi-line strings and `Infinity` values).
+     * **Not JSON5.**
+     * The dprint implementation can use features not available in JSONC (e.g., trailing commas).
+     * But some features of JSON5 (e.g., multi-line strings, `Infinity` values) cannot be used.
      */
     "{,.}dprint.json": "jsonc",
     ".dprint[.-]*.json": "jsonc"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
   "files.associations": {
-    ".prettierignore": "ignore",
-    ".ultraignore": "ignore",
+    ".{prettier,ultra}ignore": "ignore",
     "turbo.json": "jsonc",
     /**
      * The dprint configuration file is parsed as jsonc.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,16 @@
 {
   "typescript.tsdk": "./node_modules/typescript/lib",
   "files.associations": {
-    "turbo.json": "jsonc"
+    "turbo.json": "jsonc",
+    /**
+     * The dprint configuration file is parsed as jsonc.
+     * see https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14
+     * see https://github.com/dprint/jsonc-parser
+     * Not JSON5.
+     * dprint implementation can use features not available in jsonc (e.g., trailing commas),
+     * but not some JSON5 features (e.g., multi-line strings and `Infinity` values).
+     */
+    "{,.}dprint.json": "jsonc",
+    ".dprint[.-]*.json": "jsonc"
   }
 }


### PR DESCRIPTION
Syntax highlighting in GitHub and VSCode (Visual Studio Code) works correctly for most files. However, some files are exceptions. So we will override the syntax highlighting and modify it so that it is displayed correctly.

+ `.prettierignore`

    VSCode detected this file as plain text.

+ `.ultraignore`

    Both GitHub and VSCode do not support this file.

+ `tsconfig.*.json` and `tsconfig-*.json`

    [VSCode detects these files as JSONC (JSON with Comments)](https://github.com/microsoft/vscode/blob/1.75.1/extensions/typescript-language-features/package.json#L79-L106), but [GitHub only supports `tsconfig.json`](https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L3123).

+ `dprint.json` and `.dprint.json`

    Both GitHub and VSCode do not support this file.

    The dprint configuration file is [parsed as JSONC (JSON with Comments)](https://github.com/dprint/dprint/blob/0.34.1/crates/dprint/src/configuration/deserialize_config.rs#L14). **Not JSON5**. The [dprint implementation](https://github.com/dprint/jsonc-parser) can use features not available in JSONC (e.g., [trailing commas](https://github.com/dprint/jsonc-parser/blob/0.21.0/tests/specs/object/trailing_comma.json)). But some features of JSON5 (e.g., [multi-line strings](https://json5.org/#strings), [`Infinity` values](https://json5.org/#numbers)) cannot be used.

+ `.dprint.*.json` and `.dprint-*.json`

    These are not [official dprint configuration filenames](https://github.com/dprint/dprint/blob/0.34.1/website/src/setup.md#custom-config-file-location). But we are using these files in this project.

+ `*.prototxt`

    [GitHub does not support this file](https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L5276-L5287).

    > **Note**
    > The file extension `.prototxt` is not recommended. [The canonical file extension is `.textproto`](https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files).
