### PR TITLE
chore(editor): replace the project's recommended VSCode extension "thesofakillers.vscode-pbtxt" with "thejustinwalsh.textproto-grammer"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,15 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["dbaeumer.vscode-eslint", "thesofakillers.vscode-pbtxt"],
+  "recommendations": [
+    // ESLint
+    "dbaeumer.vscode-eslint",
+    // Protocol Buffer Text Format
+    "thejustinwalsh.textproto-grammer"
+  ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-  "unwantedRecommendations": []
+  "unwantedRecommendations": [
+    // This extension is no longer maintained
+    "thesofakillers.vscode-pbtxt"
+  ]
 }


### PR DESCRIPTION
The VSCode extension `thesefakillers.vscode-pbtxt` [is no longer maintained](https://marketplace.visualstudio.com/items?itemName=thesofakillers.vscode-pbtxt).

Therefore, we recommend [`thejustinwalsh.textproto-grammer`](https://marketplace.visualstudio.com/items?itemName=thejustinwalsh.textproto-grammer) instead.