### PR TITLE
ci(github actions): use "cache" option in `actions/setup-node`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,13 +69,15 @@ jobs:
           - 16.x
     steps:
       - uses: actions/checkout@v3
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
-      - name: Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
       - name: Install Dependencies
         run: pnpm install
       - name: Build packages
@@ -133,12 +135,14 @@ jobs:
         run: |
           tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.zst --zstd
           tar -x --file ~/pre-build-artifact/build_results.tar.zst --zstd
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
       - name: Cache actionlint
         uses: actions/cache@v3
         with:
@@ -172,12 +176,14 @@ jobs:
         run: |
           tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.zst --zstd
           tar -x --file ~/pre-build-artifact/build_results.tar.zst --zstd
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
       - name: Setup dprint
         # The dprint command may fail to deserialize the wasm module.
         # This only happens on CI, and in some cases no error occurs.
@@ -291,12 +297,14 @@ jobs:
         run: |
           tar -x --file ~/pre-build-artifact/node_modules--${{ runner.os }}.tar.zst --zstd
           tar -x --file ~/pre-build-artifact/build_results.tar.zst --zstd
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
       - name: Install flatbuffers
         # https://snapcraft.io/flatbuffers
         run: |
@@ -429,6 +437,10 @@ jobs:
         run: |
           git config --global user.name  CI
           git config --global user.email dummy@example.com
+      - name: Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,17 +73,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
       - name: Enable Corepack (Automatically setup a package manager for Node.js)
         run: corepack enable
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
       - name: Install Dependencies
         run: pnpm install
       - name: Build packages
@@ -441,6 +433,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
       - name: Enable Corepack (Automatically setup a package manager for Node.js)
         shell: bash
         # If Corepack does not exist or a Corepack version range is specified, install Corepack
@@ -461,16 +454,6 @@ jobs:
           echo '::group::$' corepack enable
           corepack enable
           echo '::endgroup::'
-      - name: Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
-        if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}
       - name: Install Dependencies
         run: pnpm install
         if: ${{ ! steps.restore-deps-and-build.outputs.node_modules }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,19 +123,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: pnpm
         if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Enable Corepack (Automatically setup a package manager for Node.js)
         run: corepack enable
-        if: ${{ steps.release-pr.outputs.ref }}
-      - name: Commit to Release PR / Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-16.x-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-16.x-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
         if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Install Dependencies
         run: pnpm install
@@ -211,22 +202,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: pnpm
           registry-url: https://registry.npmjs.org
           # Note: The `registry-url` option is required.
           #       If this option is not set, the "npm publish" command will not detect the environment variable NODE_AUTH_TOKEN.
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Enable Corepack (Automatically setup a package manager for Node.js)
         run: corepack enable
-        if: ${{ steps.release.outputs.releases_created }}
-      - name: Publish / Cache .pnpm-store
-        uses: actions/cache@v3
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-16.x-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-16.x-
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,14 +119,16 @@ jobs:
           # All commit logs are required to update CHANGELOG.md by scripts/fix-changelog.mjs
           fetch-depth: 0
         if: ${{ steps.release-pr.outputs.ref }}
+      - name: Commit to Release PR / Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
+        if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: pnpm
-        if: ${{ steps.release-pr.outputs.ref }}
-      - name: Commit to Release PR / Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
         if: ${{ steps.release-pr.outputs.ref }}
       - name: Commit to Release PR / Install Dependencies
         run: pnpm install
@@ -198,6 +200,11 @@ jobs:
       - name: Publish / Checkout
         uses: actions/checkout@v3
         if: ${{ steps.release.outputs.releases_created }}
+      - name: Publish / Enable Corepack (Automatically setup a package manager for Node.js)
+        # Note: We need to enable pnpm before running `actions/setup-node`.
+        #       Because the `cache: pnpm` option executes pnpm.
+        run: corepack enable
+        if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -206,9 +213,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           # Note: The `registry-url` option is required.
           #       If this option is not set, the "npm publish" command will not detect the environment variable NODE_AUTH_TOKEN.
-        if: ${{ steps.release.outputs.releases_created }}
-      - name: Publish / Enable Corepack (Automatically setup a package manager for Node.js)
-        run: corepack enable
         if: ${{ steps.release.outputs.releases_created }}
       - name: Publish / Install Dependencies
         run: pnpm install


### PR DESCRIPTION
`actions/setup-node` has [a "cache" option to cache dependencies for each package manager](https://github.com/actions/setup-node/tree/v3.6.0#caching-global-packages-data).
This might allow us to omit the step of caching `.pnpm-store`.