### PR TITLE
chore: release get-nodejs-versions-array-action 0.0.1

### DIFF
--- a/actions/get-nodejs-versions-array/CHANGELOG.md
+++ b/actions/get-nodejs-versions-array/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+
+## 0.0.1 (2023-03-04)
+
+### Commits
+
+<details><summary>show 1 commits</summary>
+
+* [`a40259b4`](https://github.com/sounisi5011/npm-packages/commit/a40259b495370afe961318ba500f3b6cdb79746d) ci(github actions): auto-detect the version of Node.js used in unit tests ([#675](https://github.com/sounisi5011/npm-packages/issues/675))
+
+</details>


### PR DESCRIPTION
`google-github-actions/release-please-action@v2` will not create release pull requests from commits that do not affect Semantic Versioning. Therefore, I will create a release PR manually.

---
### 0.0.1 (2023-03-04)
