### PR TITLE
ci(release): fix automatic releases - do not use `steps.release.outputs.releases_created`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -492,28 +492,3 @@ jobs:
             || contains(needs.*.result, 'skipped')
           }}
         run: exit 1
-
-  debug-env-context:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set test_flag env
-        shell: bash
-        run: |
-          echo "test_flag=true" >> "${GITHUB_ENV}"
-
-      - name: Should be skipped
-        run: echo ok
-        if: ${{ ! env.test_flag }}
-      - name: Should be skipped 2
-        run: echo ok
-        if: ${{ ! env.test_flag }}
-
-      - name: Should not be skipped
-        run: echo good
-        if: ${{ env.test_flag }}
-      - name: Should not be skipped 2
-        run: echo good
-        if: ${{ env.test_flag }}
-
-      - name: Check environment variables
-        run: node -p 'Object.fromEntries(Object.entries(process.env).filter(([k]) => /^test_?flag$/i.test(k)))'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -492,3 +492,28 @@ jobs:
             || contains(needs.*.result, 'skipped')
           }}
         run: exit 1
+
+  debug-env-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set test_flag env
+        shell: bash
+        run: |
+          echo "test_flag=true" >> "${GITHUB_ENV}"
+
+      - name: Should be skipped
+        run: echo ok
+        if: ${{ ! env.test_flag }}
+      - name: Should be skipped 2
+        run: echo ok
+        if: ${{ ! env.test_flag }}
+
+      - name: Should not be skipped
+        run: echo good
+        if: ${{ env.test_flag }}
+      - name: Should not be skipped 2
+        run: echo good
+        if: ${{ env.test_flag }}
+
+      - name: Check environment variables
+        run: node -p 'Object.fromEntries(Object.entries(process.env).filter(([k]) => /^test_?flag$/i.test(k)))'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,25 @@ jobs:
           echo '::group::core and graphql'
           echo "${RATE_LIMIT_JSON}" | jq -r '.resources | [.core, .graphql]'
           echo '::endgroup::'
+      - name: Set release_created env
+        shell: bash
+        run: |
+          echo "release_created=true" >> "${GITHUB_ENV}"
+        if: ${{ steps.release.outputs.tag_name }}
+        # Do not use "steps.release.outputs.releases_created" to check if a release has been created.
+        # The output "releases_created" is not set if:
+        #
+        # 1. release-please-action has created a release pull request.
+        #    However, no release has been made yet.
+        # 2. The release pull request _that release-please-action did not create_ has been merged and a release has been created.
+        #
+        # In the second condition, the pull request has already been closed and the branch deleted.
+        # Therefore, "Commit to Release PR" will not execute successfully.
+        # This happens, for example, when a PR like this is merged:
+        #   https://github.com/sounisi5011/npm-packages/pull/678
+        #
+        # So instead of "steps.release.outputs.releases_created", use "steps.release.outputs.tag_name".
+        # This should work as expected.
 
         #
         # Commit to PR
@@ -110,7 +129,7 @@ jobs:
           PULL_REQUEST="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ steps.release.outputs.pr }}")"
           ref="$(echo "${PULL_REQUEST}" | jq -r '.head.ref')"
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
-        if: ${{ ! steps.release.outputs.releases_created && steps.release.outputs.pr }}
+        if: ${{ ! env.release_created && steps.release.outputs.pr }}
       - name: Commit to Release PR / Checkout
         uses: actions/checkout@v3
         with:
@@ -206,7 +225,7 @@ jobs:
         #
       - name: Publish / Checkout
         uses: actions/checkout@v3
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -214,10 +233,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           # Note: The `registry-url` option is required.
           #       If this option is not set, the "npm publish" command will not detect the environment variable NODE_AUTH_TOKEN.
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Enable Corepack (Automatically setup a package manager for Node.js)
         run: corepack enable
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Cache .pnpm-store
         uses: actions/cache@v3
         with:
@@ -227,19 +246,19 @@ jobs:
             ${{ runner.os }}-node-16.x-
             ${{ runner.os }}-node-
             ${{ runner.os }}-
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Install Dependencies
         run: pnpm install
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Build
         run: pnpm exec turbo run build --filter='./${{ matrix.path-git-relative }}'
         # If there are other submodules in the dependency, it may be necessary to build the dependent submodule.
         # Therefore, build only the submodules included in the required dependencies.
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish / Update README
         run: |
           node ./scripts/publish-convert-readme.mjs '${{ steps.release.outputs.tag_name }}' '${{ matrix.path-git-relative }}/README.md'
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
@@ -267,4 +286,4 @@ jobs:
             pnpm publish --access=public --no-git-checks
           fi
         shell: bash
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ env.release_created }}


### PR DESCRIPTION
Do not use `steps.release.outputs.releases_created` to check if a release has been created.
The output `releases_created` is not set if:

1. release-please-action has created a release pull request.
   However, no release has been made yet.

2. The release pull request _that release-please-action did not create_ has been merged and a release has been created.

In the second condition, the pull request has already been closed and the branch deleted.
Therefore, ["Commit to Release PR"](https://github.com/sounisi5011/npm-packages/blob/b4d89a4782fa93d73d7df6d8182437a115ef110e/.github/workflows/release.yaml#L100-L202) will not execute successfully.
This happens, for example, when a PR like this is merged: https://github.com/sounisi5011/npm-packages/pull/678

So instead of `steps.release.outputs.releases_created`, use `steps.release.outputs.tag_name`.
This should work as expected.