### PR TITLE
fix(get-nodejs-versions-array-action): add about short references in `README.md`

### DIFF
--- a/actions/get-nodejs-versions-array/README.md
+++ b/actions/get-nodejs-versions-array/README.md
@@ -53,6 +53,11 @@ jobs:
         uses: actions/checkout@v3
       - id: detector
         uses: sounisi5011/npm-packages/actions/get-nodejs-versions-array@get-nodejs-versions-array-action-v0
+        # Alternatively, you can use short references
+        # uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-v0
+        # uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-v0.0
+        # uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-v0.0.2
+        # uses: sounisi5011/npm-packages@actions/get-nodejs-versions-array-latest
   unit-test:
     needs: detect-supported-node
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that we know this works correctly, we will add it to the documentation.